### PR TITLE
double slash fix

### DIFF
--- a/src/Data/URI.purs
+++ b/src/Data/URI.purs
@@ -34,14 +34,14 @@ parseURIRef = (Left <$> try parseURI)
           <|> (Right <$> parseRelativeRef)
 
 parseURI :: Parser URI
-parseURI = URI <$> (parseScheme <* string ":")
+parseURI = URI <$> (parseScheme <* string "://")
                <*> parseHierarchicalPart
                <*> optionMaybe (string "?" *> parseQuery)
                <*> optionMaybe (string "#" *> parseFragment)
                <* eof
 
 parseAbsoluteURI :: Parser AbsoluteURI
-parseAbsoluteURI = AbsoluteURI <$> (parseScheme <* string ":")
+parseAbsoluteURI = AbsoluteURI <$> (parseScheme <* string "://")
                                <*> parseHierarchicalPart
                                <*> optionMaybe (string "?" *> parseQuery)
                                <* eof

--- a/src/Data/URI/HierarchicalPart.purs
+++ b/src/Data/URI/HierarchicalPart.purs
@@ -14,10 +14,18 @@ import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (string)
 
 parseHierarchicalPart :: Parser HierarchicalPart
-parseHierarchicalPart = (HierarchicalPart <$> optionMaybe (string "//" *> parseAuthority) <*> parsePathAbEmpty parseURIPathAbs)
-                    <|> (HierarchicalPart Nothing <$> ((Just <$> parsePathAbsolute parseURIPathAbs)
-                                                  <|> (Just <$> parsePathRootless parseURIPathAbs)
-                                                  <|> pure Nothing))
+parseHierarchicalPart =
+  (HierarchicalPart
+   <$> optionMaybe parseAuthority
+   <*> parsePathAbEmpty parseURIPathAbs)
+  <|>
+  (HierarchicalPart Nothing
+   <$> ((Just
+         <$> parsePathAbsolute parseURIPathAbs)
+        <|>
+        (Just <$> parsePathRootless parseURIPathAbs)
+        <|>
+        pure Nothing))
 
 printHierPart :: HierarchicalPart -> String
 printHierPart (HierarchicalPart a p) =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,6 +12,7 @@ import Text.Parsing.StringParser
 
 
 main = do
+  test runParseURIRef "sql2:///?q=%28select%20%2A%20from%20%22%2Ffoo%2Fdemo%2FflatViz%22%29&var.foo=bar"
   test runParseURIRef "mongodb://localhost"
   test runParseURIRef "http://en.wikipedia.org/wiki/URI_scheme"
   test runParseURIRef "http://local.slamdata.com/?#?sort=asc&q=path%3A%2F&salt=1177214"


### PR DESCRIPTION
This fixes parsing of uri like `sql:///?q=sql-query&var.foo=bar`
I need this in SD-1115 for configure view mount buttons.
@jonsterling please, review
