### PR TITLE
Empty hierarchical

### DIFF
--- a/src/Data/URI/Authority.purs
+++ b/src/Data/URI/Authority.purs
@@ -13,14 +13,16 @@ import Data.URI.UserInfo
 import Global (readInt)
 import qualified Data.String as S
 import Text.Parsing.StringParser (Parser(), fail)
-import Text.Parsing.StringParser.Combinators (optionMaybe, sepBy1)
+import Text.Parsing.StringParser.Combinators (optionMaybe, sepBy)
 import Text.Parsing.StringParser.String (string)
 
 parseAuthority :: Parser Authority
 parseAuthority = do
   ui <- optionMaybe parseUserInfo
-  hosts <- flip sepBy1 (string ",") $ Tuple <$> parseHost
-                                            <*> optionMaybe (string ":" *> parsePort)
+  hosts <- flip sepBy (string ",")
+           $ Tuple
+             <$> parseHost
+             <*> optionMaybe (string ":" *> parsePort)
   return $ Authority ui (fromList hosts)
 
 parsePort :: Parser Port

--- a/src/Data/URI/HierarchicalPart.purs
+++ b/src/Data/URI/HierarchicalPart.purs
@@ -14,10 +14,17 @@ import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (string)
 
 parseHierarchicalPart :: Parser HierarchicalPart
-parseHierarchicalPart = (HierarchicalPart <$> optionMaybe (string "//" *> parseAuthority) <*> parsePathAbEmpty parseURIPathAbs)
-                    <|> (HierarchicalPart Nothing <$> ((Just <$> parsePathAbsolute parseURIPathAbs)
-                                                  <|> (Just <$> parsePathRootless parseURIPathAbs)
-                                                  <|> pure Nothing))
+parseHierarchicalPart =
+  (HierarchicalPart
+   <$> optionMaybe (string "//" *> parseAuthority)
+   <*> parsePathAbEmpty parseURIPathAbs)
+
+  <|> (HierarchicalPart Nothing
+       <$> ((Just <$> parsePathAbsolute parseURIPathAbs)
+            <|>
+            (Just <$> parsePathRootless parseURIPathAbs)
+            <|>
+            pure Nothing))
 
 printHierPart :: HierarchicalPart -> String
 printHierPart (HierarchicalPart a p) =

--- a/src/Data/URI/Host.purs
+++ b/src/Data/URI/Host.purs
@@ -26,7 +26,16 @@ parseIPv4Address = IPv4Address <$> rxPat pattern <?> "IPv4 address"
   octet = "(1[0-9]{2}|[1-9][0-9]|[0-9]|2[0-4][0-9]|25[0-5])"
 
 parseRegName :: Parser Host
-parseRegName = NameAddress <$> try (joinWith "" <$> many1 (parseUnreserved <|> parsePCTEncoded <|> parseSubDelims))
+parseRegName =
+  NameAddress
+    <$> try
+    (joinWith ""
+     <$> many1 (parseUnreserved
+               <|>
+               parsePCTEncoded
+               <|>
+               parseSubDelims)
+    )
 
 printHost :: Host -> String
 printHost (IPv6Address i) = "[" ++ i ++ "]"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,6 +12,7 @@ import Text.Parsing.StringParser
 
 
 main = do
+  test runParseURIRef "sql2:///?q=foo&var.bar=baz"
   test runParseURIRef "mongodb://localhost"
   test runParseURIRef "http://en.wikipedia.org/wiki/URI_scheme"
   test runParseURIRef "http://local.slamdata.com/?#?sort=asc&q=path%3A%2F&salt=1177214"


### PR DESCRIPTION
According to RFC3986 `host = IP-literal / IPv4address / reg-name` and `reg-name = *( unreserved / pct-encoded / sub-delims )` and `reg-name` is used only for defining `host`. 

@garyb please, please review
