### PR TITLE
Authority part parsing fixes

### DIFF
--- a/src/Data/URI/HierarchicalPart.purs
+++ b/src/Data/URI/HierarchicalPart.purs
@@ -14,17 +14,19 @@ import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (string)
 
 parseHierarchicalPart :: Parser HierarchicalPart
-parseHierarchicalPart =
-  (HierarchicalPart
-   <$> optionMaybe (string "//" *> parseAuthority)
-   <*> parsePathAbEmpty parseURIPathAbs)
+parseHierarchicalPart = withAuth <|> withoutAuth
+  where
+  withAuth =
+    HierarchicalPart
+      <$> Just <$> (string "//" *> parseAuthority)
+      <*> parsePathAbEmpty parseURIPathAbs
 
-  <|> (HierarchicalPart Nothing
-       <$> ((Just <$> parsePathAbsolute parseURIPathAbs)
-            <|>
-            (Just <$> parsePathRootless parseURIPathAbs)
-            <|>
-            pure Nothing))
+  withoutAuth = HierarchicalPart Nothing <$> noAuthPath
+
+  noAuthPath
+      = (Just <$> parsePathAbsolute parseURIPathAbs)
+    <|> (Just <$> parsePathRootless parseURIPathAbs)
+    <|> pure Nothing
 
 printHierPart :: HierarchicalPart -> String
 printHierPart (HierarchicalPart a p) =

--- a/src/Data/URI/RelativePart.purs
+++ b/src/Data/URI/RelativePart.purs
@@ -14,10 +14,20 @@ import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (string)
 
 parseRelativePart :: Parser RelativePart
-parseRelativePart = (RelativePart <$> optionMaybe (string "//" *> parseAuthority) <*> parsePathAbEmpty parseURIPathRel)
-                <|> (RelativePart Nothing <$> ((Just <$> parsePathAbsolute parseURIPathRel)
-                                          <|> (Just <$> parsePathNoScheme parseURIPathRel)
-                                          <|> pure Nothing))
+parseRelativePart = withAuth <|> withoutAuth
+  where
+
+  withAuth =
+    RelativePart
+      <$> Just <$> (string "//" *> parseAuthority)
+      <*> parsePathAbEmpty parseURIPathRel
+
+  withoutAuth = RelativePart Nothing <$> noAuthPath
+
+  noAuthPath
+      = (Just <$> parsePathAbsolute parseURIPathRel)
+    <|> (Just <$> parsePathNoScheme parseURIPathRel)
+    <|> pure Nothing
 
 printRelativePart :: RelativePart -> String
 printRelativePart (RelativePart a p) =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -34,6 +34,8 @@ main = do
   test runParseURIRef "foo://example.com:8042/over/there?name=ferret#nose"
   test runParseURIRef "foo://info.example.com?fred"
   test runParseURIRef "ftp://cnn.example.com&story=breaking_news@10.0.0.1/top_story.htm"
+  test runParseURIRef "../top_story.htm"
+  test runParseURIRef "top_story.htm"
 
   C.log "\nFailing test cases: "
   testFails runParseURIRef "news:comp.infosystems.www.servers.unix"
@@ -41,8 +43,6 @@ main = do
   testFails runParseURIRef "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
   testFails runParseURIRef "mailto:John.Doe@example.com"
   testFails runParseURIRef "mailto:fred@example.com"
-  testFails runParseURIRef "../top_story.htm"
-  testFails runParseURIRef "top_story.htm"
   testFails runParseURIRef "/top_story.htm"
 
 


### PR DESCRIPTION
@cryogenian could you review this please?

The change here is that the parsers that optionally accept an `Authority` would always fail when the authority was not present, as they're supposed to branch depending on whether the authority is present, but instead had an `optionMaybe` in there.

Fixing the parser this way enables the test cases for `../top_story.htm` and `top_story.htm` to pass successfully now too.

Also a tweak to the pretty printer: usually we'd probably write "foo.htm" rather than "./foo.htm" for a relative file path, but with pathy's normal pretty printing we were getting the latter.
