### PR TITLE
[BREAKING] Runs encodeURI after pretty printing URIs

### DIFF
--- a/src/Data/URI.purs
+++ b/src/Data/URI.purs
@@ -6,18 +6,13 @@ module Data.URI
 import Prelude
 
 import Control.Alt ((<|>))
-
-import Data.Array (catMaybes)
-import Data.Either (Either(..), either)
-import Data.Maybe (Maybe(..))
-import Data.String as S
+import Data.Either (Either(..))
 import Data.URI.Fragment (parseFragment)
-import Data.URI.HierarchicalPart (printHierPart, parseHierarchicalPart)
-import Data.URI.Query (printQuery, parseQuery)
-import Data.URI.RelativePart (printRelativePart, parseRelativePart)
-import Data.URI.Scheme (printScheme, parseScheme)
+import Data.URI.HierarchicalPart (parseHierarchicalPart)
+import Data.URI.Query (parseQuery)
+import Data.URI.RelativePart (parseRelativePart)
+import Data.URI.Scheme (parseScheme)
 import Data.URI.Types (Fragment, Port, URIPath, URIPathAbs, URIPathRel, URIRef, UserInfo, AbsoluteURI(..), Authority(..), HierarchicalPart(..), Host(..), Query(..), RelativePart(..), RelativeRef(..), URI(..), URIScheme(..))
-
 import Text.Parsing.StringParser (Parser, ParseError, runParser, try)
 import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (string, eof)
@@ -60,31 +55,3 @@ parseRelativeRef = RelativeRef
   <*> optionMaybe (string "?" *> parseQuery)
   <*> optionMaybe (string "#" *> parseFragment)
   <* eof
-
-printURIRef ∷ URIRef → String
-printURIRef = either printURI printRelativeRef
-
-printURI ∷ URI → String
-printURI (URI s h q f) =
-  S.joinWith "" $ catMaybes
-    [ printScheme <$> s
-    , Just (printHierPart h)
-    , printQuery <$> q
-    , ("#" <> _) <$> f
-    ]
-
-printAbsoluteURI ∷ AbsoluteURI → String
-printAbsoluteURI (AbsoluteURI s h q) =
-  S.joinWith "" $ catMaybes
-    [ printScheme <$> s
-    , Just (printHierPart h)
-    , printQuery <$> q
-    ]
-
-printRelativeRef ∷ RelativeRef → String
-printRelativeRef (RelativeRef h q f) =
-  S.joinWith "" $ catMaybes
-    [ Just (printRelativePart h)
-    , printQuery <$> q
-    , ("#" <> _) <$> f
-    ]

--- a/src/Data/URI/Printer.purs
+++ b/src/Data/URI/Printer.purs
@@ -1,0 +1,47 @@
+-- | Functions to pretty-print URIs.
+-- |
+-- | All the functions in this module run encodeURI on their output, so you
+-- | shouldn't call encodeURI on your hierarchical part or Query before
+-- | constructing URIs.
+module Data.URI.Printer where
+
+import Prelude
+
+import Data.Array (catMaybes)
+import Data.Either (either)
+import Data.Maybe (Maybe(..))
+import Data.String as S
+import Data.URI.HierarchicalPart (printHierPart)
+import Data.URI.Query (printQuery)
+import Data.URI.RelativePart (printRelativePart)
+import Data.URI.Scheme (printScheme)
+import Data.URI.Types (AbsoluteURI(..), RelativeRef(..), URI(..), URIRef)
+import Global (encodeURI)
+
+printURIRef ∷ URIRef → String
+printURIRef = either printURI printRelativeRef
+
+printURI ∷ URI → String
+printURI (URI s h q f) =
+  encodeURI $ S.joinWith "" $ catMaybes
+    [ printScheme <$> s
+    , Just (printHierPart h)
+    , printQuery <$> q
+    , ("#" <> _) <$> f
+    ]
+
+printAbsoluteURI ∷ AbsoluteURI → String
+printAbsoluteURI (AbsoluteURI s h q) =
+  encodeURI $ S.joinWith "" $ catMaybes
+    [ printScheme <$> s
+    , Just (printHierPart h)
+    , printQuery <$> q
+    ]
+
+printRelativeRef ∷ RelativeRef → String
+printRelativeRef (RelativeRef h q f) =
+  encodeURI $ S.joinWith "" $ catMaybes
+    [ Just (printRelativePart h)
+    , printQuery <$> q
+    , ("#" <> _) <$> f
+    ]

--- a/src/Data/URI/Printer.purs
+++ b/src/Data/URI/Printer.purs
@@ -23,25 +23,25 @@ printURIRef = either printURI printRelativeRef
 
 printURI ∷ URI → String
 printURI (URI s h q f) =
-  encodeURI $ S.joinWith "" $ catMaybes
+  S.joinWith "" $ catMaybes
     [ printScheme <$> s
-    , Just (printHierPart h)
+    , Just (encodeURI (printHierPart h))
     , printQuery <$> q
     , ("#" <> _) <$> f
     ]
 
 printAbsoluteURI ∷ AbsoluteURI → String
 printAbsoluteURI (AbsoluteURI s h q) =
-  encodeURI $ S.joinWith "" $ catMaybes
+  S.joinWith "" $ catMaybes
     [ printScheme <$> s
-    , Just (printHierPart h)
+    , Just (encodeURI (printHierPart h))
     , printQuery <$> q
     ]
 
 printRelativeRef ∷ RelativeRef → String
 printRelativeRef (RelativeRef h q f) =
-  encodeURI $ S.joinWith "" $ catMaybes
-    [ Just (printRelativePart h)
+  S.joinWith "" $ catMaybes
+    [ Just (encodeURI (printRelativePart h))
     , printQuery <$> q
     , ("#" <> _) <$> f
     ]


### PR DESCRIPTION
Also extract the functions into a `Printer` module (makes sure compilation fails so we don't silently break people's code).