### PR TITLE
Re-export everything relevant from each module

### DIFF
--- a/src/Data/URI.purs
+++ b/src/Data/URI.purs
@@ -1,133 +1,31 @@
-module Data.URI where
+module Data.URI
+  ( module Data.URI.AbsoluteURI
+  , module Data.URI.Authority
+  , module Data.URI.Fragment
+  , module Data.URI.HierarchicalPart
+  , module Data.URI.Host
+  , module Data.URI.Path
+  , module Data.URI.Port
+  , module Data.URI.Query
+  , module Data.URI.RelativePart
+  , module Data.URI.RelativeRef
+  , module Data.URI.Scheme
+  , module Data.URI.URI
+  , module Data.URI.URIRef
+  , module Data.URI.UserInfo
+  ) where
 
-import Prelude
-
-import Data.Either (Either)
-import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
-import Data.List (List)
-import Data.Maybe (Maybe)
-import Data.Monoid (class Monoid)
-import Data.Newtype (class Newtype)
-import Data.Path.Pathy (Path, File, Dir, Abs, Rel, Sandboxed, Unsandboxed)
-import Data.Tuple (Tuple)
-
--- | A generic URI
-data URI = URI (Maybe Scheme) HierarchicalPart (Maybe Query) (Maybe Fragment)
-
-derive instance eqURI ∷ Eq URI
-derive instance ordURI ∷ Ord URI
-derive instance genericURI ∷ Generic URI _
-instance showURI ∷ Show URI where show = genericShow
-
--- | An absolute URI.
-data AbsoluteURI = AbsoluteURI (Maybe Scheme) HierarchicalPart (Maybe Query)
-
-derive instance eqAbsoluteURI ∷ Eq AbsoluteURI
-derive instance ordAbsoluteURI ∷ Ord AbsoluteURI
-derive instance genericAbsoluteURI ∷ Generic AbsoluteURI _
-instance showAbsoluteURI ∷ Show AbsoluteURI where show = genericShow
-
--- | A relative reference for a URI.
-data RelativeRef = RelativeRef RelativePart (Maybe Query) (Maybe Fragment)
-
-derive instance eqRelativeRef ∷ Eq RelativeRef
-derive instance ordRelativeRef ∷ Ord RelativeRef
-derive instance genericRelativeRef ∷ Generic RelativeRef _
-instance showRelativeRef ∷ Show RelativeRef where show = genericShow
-
--- | A general URI path, can be used to represent relative or absolute paths
--- | that are sandboxed or unsandboxed.
-type URIPath a s = Either (Path a Dir s) (Path a File s)
-
--- | The path part for a generic or absolute URI.
-type URIPathAbs = URIPath Abs Sandboxed
-
--- | The path part for a relative reference.
-type URIPathRel = URIPath Rel Unsandboxed
-
--- | An alias for the most common use case of resource identifiers.
-type URIRef = Either URI RelativeRef
-
--- | The scheme part of an absolute URI. For example: `http`, `ftp`, `git`.
-newtype Scheme = Scheme String
-
-derive newtype instance eqScheme ∷ Eq Scheme
-derive newtype instance ordScheme ∷ Ord Scheme
-derive instance genericScheme ∷ Generic Scheme _
-derive instance newtypeScheme ∷ Newtype Scheme _
-instance showScheme ∷ Show Scheme where show = genericShow
-
--- | The "hierarchical part" of a generic or absolute URI.
-data HierarchicalPart = HierarchicalPart (Maybe Authority) (Maybe URIPathAbs)
-
-derive instance eqHierarchicalPart ∷ Eq HierarchicalPart
-derive instance ordHierarchicalPart ∷ Ord HierarchicalPart
-derive instance genericHierarchicalPart ∷ Generic HierarchicalPart _
-instance showHierarchicalPart ∷ Show HierarchicalPart where show = genericShow
-
--- | The "relative part" of a relative reference.
-data RelativePart = RelativePart (Maybe Authority) (Maybe URIPathRel)
-
-derive instance eqRelativePart ∷ Eq RelativePart
-derive instance ordRelativePart ∷ Ord RelativePart
-derive instance genericRelativePart ∷ Generic RelativePart _
-instance showRelativePart ∷ Show RelativePart where show = genericShow
-
--- | The authority part of a URI. For example: `purescript.org`,
--- | `localhost:3000`, `user@example.net`
-data Authority = Authority (Maybe UserInfo) (Array (Tuple Host (Maybe Port)))
-
-derive instance eqAuthority ∷ Eq Authority
-derive instance ordAuthority ∷ Ord Authority
-derive instance genericAuthority ∷ Generic Authority _
-instance showAuthority ∷ Show Authority where show = genericShow
-
--- | The user info part of an `Authority`. For example: `user`, `foo:bar`.
-newtype UserInfo = UserInfo String
-
-derive newtype instance eqUserInfo ∷ Eq UserInfo
-derive newtype instance ordUserInfo ∷ Ord UserInfo
-derive instance genericUserInfo ∷ Generic UserInfo _
-derive instance newtypeUserInfo ∷ Newtype UserInfo _
-instance showUserInfo ∷ Show UserInfo where show = genericShow
-
--- | A host address.
-data Host
-  = IPv6Address String
-  | IPv4Address String
-  | NameAddress String
-
-derive instance eqHost ∷ Eq Host
-derive instance ordHost ∷ Ord Host
-derive instance genericHost ∷ Generic Host _
-instance showHost ∷ Show Host where show = genericShow
-
--- | A port number.
-newtype Port = Port Int
-
-derive newtype instance eqPort ∷ Eq Port
-derive newtype instance ordPort ∷ Ord Port
-derive instance genericPort ∷ Generic Port _
-derive instance newtypePort ∷ Newtype Port _
-instance showPort ∷ Show Port where show = genericShow
-
--- | The query component of a URI.
-newtype Query = Query (List (Tuple String (Maybe String)))
-
-derive newtype instance eqQuery ∷ Eq Query
-derive newtype instance ordQuery ∷ Ord Query
-derive instance genericQuery ∷ Generic Query _
-derive instance newtypeQuery ∷ Newtype Query _
-instance showQuery ∷ Show Query where show = genericShow
-derive newtype instance semigroupQuery ∷ Semigroup Query
-derive newtype instance monoidQuery ∷ Monoid Query
-
--- | The hash fragment of a URI.
-newtype Fragment = Fragment String
-
-derive newtype instance eqFragment ∷ Eq Fragment
-derive newtype instance ordFragment ∷ Ord Fragment
-derive instance genericFragment ∷ Generic Fragment _
-derive instance newtypeFragment ∷ Newtype Fragment _
-instance showFragment ∷ Show Fragment where show = genericShow
+import Data.URI.AbsoluteURI (AbsoluteURI(..))
+import Data.URI.Authority (Authority(..))
+import Data.URI.Fragment (Fragment(..))
+import Data.URI.HierarchicalPart (HierarchicalPart(..))
+import Data.URI.Host (Host(..))
+import Data.URI.Path (URIPath, URIPathAbs, URIPathRel)
+import Data.URI.Port (Port(..))
+import Data.URI.Query (Query(..))
+import Data.URI.RelativePart (RelativePart(..))
+import Data.URI.RelativeRef (RelativeRef(..))
+import Data.URI.Scheme (Scheme(..))
+import Data.URI.URI (URI(..))
+import Data.URI.URIRef (URIRef)
+import Data.URI.UserInfo (UserInfo(..))

--- a/src/Data/URI/AbsoluteURI.purs
+++ b/src/Data/URI/AbsoluteURI.purs
@@ -1,19 +1,42 @@
-module Data.URI.AbsoluteURI where
+module Data.URI.AbsoluteURI
+  ( AbsoluteURI(..)
+  , parse
+  , parser
+  , print
+  , _scheme
+  , _hierPart
+  , _query
+  , module Data.URI.HierarchicalPart
+  , module Data.URI.Query
+  , module Data.URI.Scheme
+  ) where
 
 import Prelude
 
 import Data.Array (catMaybes)
 import Data.Either (Either)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', lens)
 import Data.Maybe (Maybe(..))
 import Data.String as S
-import Data.URI (AbsoluteURI(..), HierarchicalPart, Query, Scheme)
 import Data.URI.HierarchicalPart as HPart
+import Data.URI.HierarchicalPart (Authority(..), HierarchicalPart(..), Host(..), Port(..), URIPath, URIPathAbs, URIPathRel, UserInfo(..), _IPv4Address, _IPv6Address, _NameAddress, _authority, _hosts, _path, _userInfo)
 import Data.URI.Query as Query
+import Data.URI.Query (Query(..))
 import Data.URI.Scheme as Scheme
+import Data.URI.Scheme (Scheme(..))
 import Text.Parsing.StringParser (ParseError, Parser, runParser)
 import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (eof)
+
+-- | An absolute URI.
+data AbsoluteURI = AbsoluteURI (Maybe Scheme) HierarchicalPart (Maybe Query)
+
+derive instance eqAbsoluteURI ∷ Eq AbsoluteURI
+derive instance ordAbsoluteURI ∷ Ord AbsoluteURI
+derive instance genericAbsoluteURI ∷ Generic AbsoluteURI _
+instance showAbsoluteURI ∷ Show AbsoluteURI where show = genericShow
 
 parse ∷ String → Either ParseError AbsoluteURI
 parse = runParser parser

--- a/src/Data/URI/Authority.purs
+++ b/src/Data/URI/Authority.purs
@@ -1,19 +1,41 @@
-module Data.URI.Authority where
+module Data.URI.Authority
+  ( Authority(..)
+  , parser
+  , print
+  , _userInfo
+  , _hosts
+  , module Data.URI.Host
+  , module Data.URI.Port
+  , module Data.URI.UserInfo
+  ) where
 
 import Prelude
 
 import Data.Array (fromFoldable)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', lens)
 import Data.Maybe (Maybe, maybe)
 import Data.String as S
 import Data.Tuple (Tuple(..))
-import Data.URI (Authority(..), Host, Port, UserInfo)
+import Data.URI.Host (Host(..), _IPv4Address, _IPv6Address, _NameAddress)
 import Data.URI.Host as Host
+import Data.URI.Port (Port(..))
 import Data.URI.Port as Port
+import Data.URI.UserInfo (UserInfo(..))
 import Data.URI.UserInfo as UserInfo
 import Text.Parsing.StringParser (Parser, try)
 import Text.Parsing.StringParser.Combinators (optionMaybe, sepBy)
 import Text.Parsing.StringParser.String (string)
+
+-- | The authority part of a URI. For example: `purescript.org`,
+-- | `localhost:3000`, `user@example.net`
+data Authority = Authority (Maybe UserInfo) (Array (Tuple Host (Maybe Port)))
+
+derive instance eqAuthority ∷ Eq Authority
+derive instance ordAuthority ∷ Ord Authority
+derive instance genericAuthority ∷ Generic Authority _
+instance showAuthority ∷ Show Authority where show = genericShow
 
 parser ∷ Parser Authority
 parser = do

--- a/src/Data/URI/Fragment.purs
+++ b/src/Data/URI/Fragment.purs
@@ -1,19 +1,30 @@
-module Data.URI.Fragment (parser, print) where
+module Data.URI.Fragment where
 
 import Prelude
 
 import Control.Alt ((<|>))
 import Data.Either (fromRight)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Newtype (class Newtype)
 import Data.String as S
 import Data.String.Regex as RX
 import Data.String.Regex.Flags as RXF
-import Data.URI (Fragment(..))
 import Data.URI.Common (decodePCTComponent, joinWith, parsePChar)
 import Global (encodeURIComponent)
 import Partial.Unsafe (unsafePartial)
 import Text.Parsing.StringParser (Parser)
 import Text.Parsing.StringParser.Combinators (many)
 import Text.Parsing.StringParser.String (string)
+
+-- | The hash fragment of a URI.
+newtype Fragment = Fragment String
+
+derive newtype instance eqFragment ∷ Eq Fragment
+derive newtype instance ordFragment ∷ Ord Fragment
+derive instance genericFragment ∷ Generic Fragment _
+derive instance newtypeFragment ∷ Newtype Fragment _
+instance showFragment ∷ Show Fragment where show = genericShow
 
 parser ∷ Parser Fragment
 parser = string "#" *>

--- a/src/Data/URI/Host.purs
+++ b/src/Data/URI/Host.purs
@@ -1,17 +1,39 @@
-module Data.URI.Host where
+module Data.URI.Host
+  ( Host(..)
+  , parser
+  , ipv6AddressParser
+  , ipv4AddressParser
+  , regNameParser
+  , print
+  , _IPv6Address
+  , _IPv4Address
+  , _NameAddress
+  ) where
 
 import Prelude
 
 import Control.Alt ((<|>))
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Int as Int
 import Data.Lens (Prism', prism')
 import Data.Maybe (Maybe(..))
-import Data.URI (Host(..))
 import Data.URI.Common (decodePCT, joinWith, parsePCTEncoded, parseSubDelims, parseUnreserved, rxPat)
 import Global (encodeURI)
 import Text.Parsing.StringParser (Parser, try, fail)
 import Text.Parsing.StringParser.Combinators ((<?>), many1)
 import Text.Parsing.StringParser.String (string, char)
+
+-- | A host address.
+data Host
+  = IPv6Address String
+  | IPv4Address String
+  | NameAddress String
+
+derive instance eqHost ∷ Eq Host
+derive instance ordHost ∷ Ord Host
+derive instance genericHost ∷ Generic Host _
+instance showHost ∷ Show Host where show = genericShow
 
 parser ∷ Parser Host
 parser = ipv6AddressParser <|> ipv4AddressParser <|> try regNameParser

--- a/src/Data/URI/Host/Gen.purs
+++ b/src/Data/URI/Host/Gen.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad.Gen as Gen
 import Data.String as S
-import Data.URI (Host(..))
+import Data.URI.Host (Host(..))
 
 genIPv4 :: forall m. Gen.MonadGen m => m Host
 genIPv4 = do

--- a/src/Data/URI/Path.purs
+++ b/src/Data/URI/Path.purs
@@ -1,5 +1,8 @@
 module Data.URI.Path
-  ( parsePath
+  ( URIPath
+  , URIPathAbs
+  , URIPathRel
+  , parsePath
   , parsePathAbEmpty
   , parsePathAbsolute
   , parsePathNoScheme
@@ -17,14 +20,23 @@ import Prelude
 import Control.Alt ((<|>))
 import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Path.Pathy (Path, Escaper(..), parseAbsDir, parseRelDir, parseAbsFile, parseRelFile, sandbox, rootDir, (</>), unsafePrintPath')
+import Data.Path.Pathy (Abs, Dir, Escaper(..), File, Path, Rel, Sandboxed, Unsandboxed, parseAbsDir, parseAbsFile, parseRelDir, parseRelFile, rootDir, sandbox, unsafePrintPath', (</>))
 import Data.String as Str
-import Data.URI (URIPath, URIPathRel, URIPathAbs)
 import Data.URI.Common (PCTEncoded, decodePCT, joinWith, parsePCTEncoded, parsePChar, parseSubDelims, parseUnreserved, wrapParser)
 import Global (encodeURI)
 import Text.Parsing.StringParser (Parser(..), ParseError(..), try)
 import Text.Parsing.StringParser.Combinators (many, many1)
 import Text.Parsing.StringParser.String (string)
+
+-- | A general URI path, can be used to represent relative or absolute paths
+-- | that are sandboxed or unsandboxed.
+type URIPath a s = Either (Path a Dir s) (Path a File s)
+
+-- | The path part for a generic or absolute URI.
+type URIPathAbs = URIPath Abs Sandboxed
+
+-- | The path part for a relative reference.
+type URIPathRel = URIPath Rel Unsandboxed
 
 parsePath ∷ ∀ p. Parser p → Parser (Maybe p)
 parsePath p

--- a/src/Data/URI/Port.purs
+++ b/src/Data/URI/Port.purs
@@ -2,12 +2,23 @@ module Data.URI.Port where
 
 import Prelude
 
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Int (fromNumber)
 import Data.Maybe (Maybe(..))
-import Data.URI (Port(..))
+import Data.Newtype (class Newtype)
 import Data.URI.Common (rxPat)
 import Global (readInt)
 import Text.Parsing.StringParser (Parser, fail)
+
+-- | A port number.
+newtype Port = Port Int
+
+derive newtype instance eqPort ∷ Eq Port
+derive newtype instance ordPort ∷ Ord Port
+derive instance genericPort ∷ Generic Port _
+derive instance newtypePort ∷ Newtype Port _
+instance showPort ∷ Show Port where show = genericShow
 
 parser ∷ Parser Port
 parser = do

--- a/src/Data/URI/Query.purs
+++ b/src/Data/URI/Query.purs
@@ -1,22 +1,40 @@
-module Data.URI.Query (parser, print) where
+module Data.URI.Query
+  ( Query(..)
+  , parser
+  , print
+  ) where
 
 import Prelude
 
 import Control.Alt ((<|>))
 import Data.Either (fromRight)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.List (List(..))
 import Data.Maybe (Maybe(..))
+import Data.Monoid (class Monoid)
+import Data.Newtype (class Newtype)
 import Data.String as S
 import Data.String.Regex as RX
 import Data.String.Regex.Flags as RXF
 import Data.Tuple (Tuple(..))
-import Data.URI (Query(..))
 import Data.URI.Common (joinWith, rxPat, wrapParser)
 import Global (decodeURIComponent, encodeURIComponent)
 import Partial.Unsafe (unsafePartial)
 import Text.Parsing.StringParser (Parser, try)
 import Text.Parsing.StringParser.Combinators (optionMaybe, sepBy)
 import Text.Parsing.StringParser.String (string)
+
+-- | The query component of a URI.
+newtype Query = Query (List (Tuple String (Maybe String)))
+
+derive newtype instance eqQuery ∷ Eq Query
+derive newtype instance ordQuery ∷ Ord Query
+derive instance genericQuery ∷ Generic Query _
+derive instance newtypeQuery ∷ Newtype Query _
+instance showQuery ∷ Show Query where show = genericShow
+derive newtype instance semigroupQuery ∷ Semigroup Query
+derive newtype instance monoidQuery ∷ Monoid Query
 
 parser ∷ Parser Query
 parser = string "?" *> (Query <$> wrapParser parseParts (try (rxPat "[^#]*")))

--- a/src/Data/URI/RelativePart.purs
+++ b/src/Data/URI/RelativePart.purs
@@ -1,16 +1,35 @@
-module Data.URI.RelativePart where
+module Data.URI.RelativePart
+  ( RelativePart(..)
+  , parser
+  , print
+  , _authority
+  , _path
+  , module Data.URI.Authority
+  , module Data.URI.Path
+  ) where
 
 import Prelude
 
 import Control.Alt ((<|>))
 import Data.Array (catMaybes)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', lens)
 import Data.Maybe (Maybe(..))
 import Data.String as S
-import Data.URI (Authority, RelativePart(..), URIPathRel)
+import Data.URI.Authority (Authority(..), Host(..), Port(..), UserInfo(..), _IPv4Address, _IPv6Address, _NameAddress, _hosts, _userInfo)
 import Data.URI.Authority as Authority
-import Data.URI.Path (printPath, parseURIPathRel, parsePathNoScheme, parsePathAbsolute, parsePathAbEmpty)
+import Data.URI.Path (URIPath, URIPathAbs, URIPathRel)
+import Data.URI.Path as Path
 import Text.Parsing.StringParser (Parser)
+
+-- | The "relative part" of a relative reference.
+data RelativePart = RelativePart (Maybe Authority) (Maybe URIPathRel)
+
+derive instance eqRelativePart ∷ Eq RelativePart
+derive instance ordRelativePart ∷ Ord RelativePart
+derive instance genericRelativePart ∷ Generic RelativePart _
+instance showRelativePart ∷ Show RelativePart where show = genericShow
 
 parser ∷ Parser RelativePart
 parser = withAuth <|> withoutAuth
@@ -19,13 +38,13 @@ parser = withAuth <|> withoutAuth
   withAuth =
     RelativePart
       <$> Just <$> Authority.parser
-      <*> parsePathAbEmpty parseURIPathRel
+      <*> Path.parsePathAbEmpty Path.parseURIPathRel
 
   withoutAuth = RelativePart Nothing <$> noAuthPath
 
   noAuthPath
-      = (Just <$> parsePathAbsolute parseURIPathRel)
-    <|> (Just <$> parsePathNoScheme parseURIPathRel)
+      = (Just <$> Path.parsePathAbsolute Path.parseURIPathRel)
+    <|> (Just <$> Path.parsePathNoScheme Path.parseURIPathRel)
     <|> pure Nothing
 
 print ∷ RelativePart → String
@@ -33,7 +52,7 @@ print (RelativePart a p) =
   S.joinWith "" $
     catMaybes
       [ Authority.print <$> a
-      , printPath <$> p
+      , Path.printPath <$> p
       ]
 
 _authority ∷ Lens' RelativePart (Maybe Authority)

--- a/src/Data/URI/RelativeRef.purs
+++ b/src/Data/URI/RelativeRef.purs
@@ -1,19 +1,42 @@
-module Data.URI.RelativeRef where
+module Data.URI.RelativeRef
+  ( RelativeRef(..)
+  , parse
+  , parser
+  , print
+  , _relPart
+  , _query
+  , _fragment
+  , module Data.URI.Fragment
+  , module Data.URI.Query
+  , module Data.URI.RelativePart
+  ) where
 
 import Prelude
 
 import Data.Array (catMaybes)
 import Data.Either (Either)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', lens)
 import Data.Maybe (Maybe(..))
 import Data.String as S
-import Data.URI (Fragment, Query, RelativePart, RelativeRef(..))
 import Data.URI.Fragment as Fragment
+import Data.URI.Fragment (Fragment(..))
 import Data.URI.Query as Query
+import Data.URI.Query (Query(..))
 import Data.URI.RelativePart as RPart
+import Data.URI.RelativePart (Authority(..), Host(..), Port(..), RelativePart(..), URIPath, URIPathAbs, URIPathRel, UserInfo(..), _IPv4Address, _IPv6Address, _NameAddress, _authority, _hosts, _path, _userInfo)
 import Text.Parsing.StringParser (Parser, ParseError, runParser)
 import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (eof)
+
+-- | A relative reference for a URI.
+data RelativeRef = RelativeRef RelativePart (Maybe Query) (Maybe Fragment)
+
+derive instance eqRelativeRef ∷ Eq RelativeRef
+derive instance ordRelativeRef ∷ Ord RelativeRef
+derive instance genericRelativeRef ∷ Generic RelativeRef _
+instance showRelativeRef ∷ Show RelativeRef where show = genericShow
 
 parse ∷ String → Either ParseError RelativeRef
 parse = runParser parser

--- a/src/Data/URI/Scheme.purs
+++ b/src/Data/URI/Scheme.purs
@@ -2,10 +2,21 @@ module Data.URI.Scheme where
 
 import Prelude
 
-import Data.URI (Scheme(..))
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Newtype (class Newtype)
 import Data.URI.Common (rxPat)
 import Text.Parsing.StringParser (Parser)
 import Text.Parsing.StringParser.String (string)
+
+-- | The scheme part of an absolute URI. For example: `http`, `ftp`, `git`.
+newtype Scheme = Scheme String
+
+derive newtype instance eqScheme ∷ Eq Scheme
+derive newtype instance ordScheme ∷ Ord Scheme
+derive instance genericScheme ∷ Generic Scheme _
+derive instance newtypeScheme ∷ Newtype Scheme _
+instance showScheme ∷ Show Scheme where show = genericShow
 
 parser ∷ Parser Scheme
 parser = Scheme <$> rxPat "[a-z][a-z0-9+\\.\\-]+" <* string ":"

--- a/src/Data/URI/URI.purs
+++ b/src/Data/URI/URI.purs
@@ -1,20 +1,46 @@
-module Data.URI.URI where
+module Data.URI.URI
+  ( URI(..)
+  , parse
+  , parser
+  , print
+  , _scheme
+  , _hierPart
+  , _query
+  , _fragment
+  , module Data.URI.Fragment
+  , module Data.URI.HierarchicalPart
+  , module Data.URI.Query
+  , module Data.URI.Scheme
+  ) where
 
 import Prelude
 
 import Data.Array (catMaybes)
 import Data.Either (Either)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', lens)
 import Data.Maybe (Maybe(..))
 import Data.String as S
-import Data.URI (Fragment, HierarchicalPart, Query, Scheme, URI(..))
+import Data.URI.Fragment (Fragment(..))
 import Data.URI.Fragment as Fragment
+import Data.URI.HierarchicalPart (Authority(..), HierarchicalPart(..), Host(..), Port(..), URIPath, URIPathAbs, URIPathRel, UserInfo(..), _IPv4Address, _IPv6Address, _NameAddress, _authority, _hosts, _path, _userInfo)
 import Data.URI.HierarchicalPart as HPart
+import Data.URI.Query (Query(..))
 import Data.URI.Query as Query
+import Data.URI.Scheme (Scheme(..))
 import Data.URI.Scheme as Scheme
 import Text.Parsing.StringParser (Parser, ParseError, runParser)
 import Text.Parsing.StringParser.Combinators (optionMaybe)
 import Text.Parsing.StringParser.String (eof)
+
+-- | A generic URI
+data URI = URI (Maybe Scheme) HierarchicalPart (Maybe Query) (Maybe Fragment)
+
+derive instance eqURI ∷ Eq URI
+derive instance ordURI ∷ Ord URI
+derive instance genericURI ∷ Generic URI _
+instance showURI ∷ Show URI where show = genericShow
 
 parse ∷ String → Either ParseError URI
 parse = runParser parser

--- a/src/Data/URI/URIRef.purs
+++ b/src/Data/URI/URIRef.purs
@@ -4,10 +4,12 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Data.Either (Either(..), either)
-import Data.URI (URIRef)
 import Data.URI.RelativeRef as RelativeRef
 import Data.URI.URI as URI
 import Text.Parsing.StringParser (Parser, ParseError, runParser, try)
+
+-- | An alias for the most common use case of resource identifiers.
+type URIRef = Either URI.URI RelativeRef.RelativeRef
 
 parse ∷ String → Either ParseError URIRef
 parse = runParser parser

--- a/src/Data/URI/UserInfo.purs
+++ b/src/Data/URI/UserInfo.purs
@@ -3,12 +3,23 @@ module Data.URI.UserInfo where
 import Prelude
 
 import Control.Alt ((<|>))
-import Data.URI (UserInfo(..))
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Newtype (class Newtype)
 import Data.URI.Common (decodePCT, joinWith, parsePCTEncoded, parseSubDelims, parseUnreserved)
 import Global (encodeURI)
 import Text.Parsing.StringParser (Parser)
 import Text.Parsing.StringParser.Combinators (many1)
 import Text.Parsing.StringParser.String (string)
+
+-- | The user info part of an `Authority`. For example: `user`, `foo:bar`.
+newtype UserInfo = UserInfo String
+
+derive newtype instance eqUserInfo ∷ Eq UserInfo
+derive newtype instance ordUserInfo ∷ Ord UserInfo
+derive instance genericUserInfo ∷ Generic UserInfo _
+derive instance newtypeUserInfo ∷ Newtype UserInfo _
+instance showUserInfo ∷ Show UserInfo where show = genericShow
 
 parser ∷ Parser UserInfo
 parser = UserInfo <<< joinWith "" <$> many1 p


### PR DESCRIPTION
Also shuffles definitions around a bit again, but the main module still exports everything it did originally.