### PR TITLE
Encode = in query keys and values

### DIFF
--- a/src/Data/URI/Query.purs
+++ b/src/Data/URI/Query.purs
@@ -70,4 +70,4 @@ printQueryPart = S.joinWith "" <<< map printChar <<< S.split (S.Pattern "")
     | otherwise = encodeURIComponent s
 
 rxPrintable ∷ RX.Regex
-rxPrintable = unsafePartial fromRight $ RX.regex "[$+=/?:@]" RXF.global
+rxPrintable = unsafePartial fromRight $ RX.regex "[$+/?:@]" RXF.global

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -475,6 +475,9 @@ main = runTest $ suite "Data.URI" do
     testPrintQuerySerializes
       (Query (Tuple "key1" (Just "value1") : Tuple "key2" (Just "value2") : Tuple "key1" (Just "value3") : Nil))
       "?key1=value1&key2=value2&key1=value3"
+    testPrintQuerySerializes
+      (Query (Tuple "k=ey" (Just "value=1") : Nil))
+      "?k%3Dey=value%3D1"
     testPrintQuerySerializes (Query Nil) "?"
     testPrintQuerySerializes
       (Query (Tuple "key1" (Just "") : Tuple "key2" (Just "") : Nil))


### PR DESCRIPTION
As `purescript-uri` encodes as if there is meaning in queries, we should probably escape `=`