### PR TITLE
Fix encoding/decoding issue of UserInfo

### DIFF
--- a/src/Data/URI/UserInfo.purs
+++ b/src/Data/URI/UserInfo.purs
@@ -6,28 +6,63 @@ import Control.Alt ((<|>))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Newtype (class Newtype)
-import Data.URI.Common (decodePCT, joinWith, parsePCTEncoded, parseSubDelims, parseUnreserved)
-import Global (encodeURI)
-import Text.Parsing.StringParser (Parser)
+import Data.URI.Common (decodePCTComponent, parsePCTEncoded, joinWith, parseSubDelims, parseUnreserved)
+import Data.String as Str
+import Data.Foldable (foldMap)
+import Global (encodeURIComponent)
+import Text.Parsing.StringParser (Parser, try)
 import Text.Parsing.StringParser.Combinators (many1)
 import Text.Parsing.StringParser.String (string)
 
 -- | The user info part of an `Authority`. For example: `user`, `foo:bar`.
-newtype UserInfo = UserInfo String
+newtype UserInfo = UserInfo { username :: String, password :: String }
 
-derive newtype instance eqUserInfo ∷ Eq UserInfo
-derive newtype instance ordUserInfo ∷ Ord UserInfo
+derive instance eqUserInfo ∷ Eq UserInfo
+derive instance ordUserInfo ∷ Ord UserInfo
 derive instance genericUserInfo ∷ Generic UserInfo _
 derive instance newtypeUserInfo ∷ Newtype UserInfo _
 instance showUserInfo ∷ Show UserInfo where show = genericShow
 
 parser ∷ Parser UserInfo
-parser = UserInfo <<< joinWith "" <$> many1 p
+parser = do 
+  username <- authPart
+  password <- (try (string ":") *> authPart) <|> pure ""
+  pure $ UserInfo { username, password }
   where
-  p = parseUnreserved
-    <|> parsePCTEncoded decodePCT
+  authPart = map (joinWith "") $ many1 $ parseUnreserved
+    <|> parsePCTEncoded decodePCTComponent
     <|> parseSubDelims
-    <|> string ":"
 
 print ∷ UserInfo → String
-print (UserInfo u) = encodeURI u
+print (UserInfo {username, password }) = 
+  let encodedUsername = encodeUserPassword username
+  in if password == "" 
+    then encodedUsername
+    else encodedUsername <> ":" <> encodeUserPassword password
+
+encodeUserPassword :: String -> String
+encodeUserPassword s = foldMap encodeChar $ Str.toCharArray s
+  where
+  -- `shouldEscape` is adopted from "net/url" of golang where mode is `encodeUserPassword`
+  -- https://golang.org/src/net/url/url.go?s=10264:10346#L102
+  shouldEscape c = 
+    -- §2.3 Unreserved characters (alphanum)
+    if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9'
+      then false 
+    -- §2.3 Unreserved characters (mark)
+    else if c == '-' || c ==  '_' || c ==  '.' || c ==  '~'
+      then false 
+    -- §2.2 Reserved characters (reserved)
+    else if c == '$' || c == '&' || c == '+' || c == ',' || c == '/' || c == ':' || c == ';' || c == '=' || c == '?' || c == '@'
+      -- The RFC allows ';', ':', '&', '=', '+', '$', and ',' in
+      -- userinfo, so we must escape only '@', '/', and '?'.
+      -- The parsing of userinfo treats ':' as special so we must escape
+      -- that too.
+      then c == '@' || c == '/' || c == '?' || c == ':'
+    else true
+    
+    
+  encodeChar :: Char -> String
+  encodeChar c =
+    let cStr = Str.singleton c
+    in if shouldEscape c then encodeURIComponent cStr else cStr

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -114,10 +114,12 @@ main = runTest $ suite "Data.URI" do
     testRunParseSuccess Scheme.parser "git+ssh:" (Scheme "git+ssh")
 
   suite "UserInfo parser" do
-    testRunParseSuccess UserInfo.parser "user" (UserInfo "user")
-    testRunParseSuccess UserInfo.parser "spaced%20user" (UserInfo "spaced user")
-    testRunParseSuccess UserInfo.parser "user:password" (UserInfo "user:password")
-    testRunParseSuccess UserInfo.parser "spaced%20user:password%25%C2%A3" (UserInfo "spaced user:password%£")
+    testRunParseSuccess UserInfo.parser "user" (UserInfo { username: "user", password: "" })
+    testRunParseSuccess UserInfo.parser "%40:%40" (UserInfo { username: "@", password: "@" })
+    testRunParseSuccess UserInfo.parser "%3A:%3A" (UserInfo { username: ":", password: ":" })
+    testRunParseSuccess UserInfo.parser "spaced%20user" (UserInfo { username: "spaced user", password: "" })
+    testRunParseSuccess UserInfo.parser "user:password" (UserInfo { username: "user", password: "password" })
+    testRunParseSuccess UserInfo.parser "spaced%20user:password%25%C2%A3" (UserInfo { username: "spaced user", password: "password%£" })
 
   suite "Host parser" do
     testRunParseSuccess Host.parser "localhost" (NameAddress "localhost")
@@ -190,7 +192,7 @@ main = runTest $ suite "Data.URI" do
           (HierarchicalPart
             (Just
               (Authority
-                (Just (UserInfo "foo:bar"))
+                (Just (UserInfo { username: "foo", password: "bar" }))
                 [ Tuple (NameAddress "db1.example.net") Nothing
                 , Tuple (NameAddress "db2.example.net") (Just (Port 2500))]))
             (Just (Right (rootDir </> file "authdb"))))
@@ -204,7 +206,7 @@ main = runTest $ suite "Data.URI" do
         (URI
           (Just (Scheme "mongodb"))
           (HierarchicalPart
-            (Just (Authority (Just (UserInfo "foo:bar")) [(Tuple (NameAddress "db1.example.net") (Just (Port 6))),(Tuple (NameAddress "db2.example.net") (Just (Port 2500)))]))
+            (Just (Authority (Just (UserInfo { username: "foo", password: "bar" })) [(Tuple (NameAddress "db1.example.net") (Just (Port 6))),(Tuple (NameAddress "db2.example.net") (Just (Port 2500)))]))
             (Just (Right (rootDir </> file "authdb"))))
           (Just (Query (Tuple "replicaSet" (Just "test") : Tuple "connectTimeoutMS" (Just "300000") : Nil)))
           Nothing))
@@ -237,7 +239,7 @@ main = runTest $ suite "Data.URI" do
         (URI
           (Just (Scheme "mongodb"))
           (HierarchicalPart
-            (Just(Authority (Just (UserInfo "sysop:moon")) [(Tuple (NameAddress "localhost") Nothing)]))
+            (Just(Authority (Just (UserInfo { username: "sysop", password: "moon" })) [(Tuple (NameAddress "localhost") Nothing)]))
             Nothing)
           Nothing
           Nothing))
@@ -247,7 +249,7 @@ main = runTest $ suite "Data.URI" do
         (URI
           (Just (Scheme "mongodb"))
           (HierarchicalPart
-            (Just (Authority (Just (UserInfo "sysop:moon")) [(Tuple (NameAddress "localhost") Nothing)]))
+            (Just (Authority (Just (UserInfo { username: "sysop", password: "moon" })) [(Tuple (NameAddress "localhost") Nothing)]))
             (Just (Left rootDir)))
           Nothing
           Nothing))
@@ -257,7 +259,7 @@ main = runTest $ suite "Data.URI" do
         (URI
           (Just (Scheme "mongodb"))
           (HierarchicalPart
-            (Just (Authority (Just (UserInfo "sysop:moon")) [(Tuple (NameAddress "localhost") Nothing)]))
+            (Just (Authority (Just (UserInfo { username: "sysop", password: "moon" })) [(Tuple (NameAddress "localhost") Nothing)]))
             (Just (Right (rootDir </> file "records"))))
           Nothing
           Nothing))
@@ -363,7 +365,7 @@ main = runTest $ suite "Data.URI" do
           (HierarchicalPart
             (Just
               (Authority
-                (Just (UserInfo "cnn.example.com&story=breaking_news"))
+                (Just (UserInfo { username: "cnn.example.com&story=breaking_news", password: "" }))
                 [(Tuple (IPv4Address "10.0.0.1") Nothing)]))
             (Just (Right (rootDir </> file "top_story.htm"))))
           Nothing


### PR DESCRIPTION
> Before this PR one couldn't use `:` or `@` in username or password now it's possible.
> 
> To achieve this representation of UserInfo changed to record instead of just string as we need to encode username and password separately (without "connecting" `:`)