### PR TITLE
Replace 'id' with 'identity' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,23 +53,23 @@ Along with these types, you'll want to define an options record that specifies h
 options ∷ Record (URIRefOptions UserInfo (HostPortPair Host Port) Path HierPath RelPath Query Fragment)
 options =
   { parseUserInfo: pure
-  , printUserInfo: id
+  , printUserInfo: identity
   , parseHosts: HostPortPair.parser pure pure
-  , printHosts: HostPortPair.print id id
+  , printHosts: HostPortPair.print identity identity
   , parsePath: pure
-  , printPath: id
+  , printPath: identity
   , parseHierPath: pure
-  , printHierPath: id
+  , printHierPath: identity
   , parseRelPath: pure
-  , printRelPath: id
+  , printRelPath: identity
   , parseQuery: pure
-  , printQuery: id
+  , printQuery: identity
   , parseFragment: pure
-  , printFragment: id
+  , printFragment: identity
   }
 ```
 
-As you can see by all the `pure` and `id`, we're not doing a whole lot here. `parseHosts` is a bit of an exception, but that's just due to the way that case is handled (see [later in this README](#host-parsing) for more details about that).
+As you can see by all the `pure` and `identity`, we're not doing a whole lot here. `parseHosts` is a bit of an exception, but that's just due to the way that case is handled (see [later in this README](#host-parsing) for more details about that).
 
 These types ([`UserInfo`][UserInfo], [`HostPortPair`][HostPortPair], [`Host`][Host], etc.) are all provided by the library, and where necessary can only be constructed via smart constructor. This ensures that percent-encoding is applied to characters where necessary to ensure the constructed values will print as valid URIs, and so on.
 

--- a/src/URI/AbsoluteURI.purs
+++ b/src/URI/AbsoluteURI.purs
@@ -80,9 +80,9 @@ type AbsoluteURIParseOptions userInfo hosts path hierPath query r =
 -- | when type anotating an options record.
 -- |
 -- | As a reverse of the parse options, this specifies how to print values back
--- | from custom representations. If this is not necessary, `id` can be used for
+-- | from custom representations. If this is not necessary, `identity` can be used for
 -- | all the options aside from `printHosts`, which will typically be
--- | `HostPortPair.printHosts id id`. See [`URI.HostPortPair`](../URI.HostPortPair)
+-- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type AbsoluteURIPrintOptions userInfo hosts path hierPath query r =
   ( printUserInfo ∷ userInfo → UserInfo

--- a/src/URI/Extra/MultiHostPortPair.purs
+++ b/src/URI/Extra/MultiHostPortPair.purs
@@ -79,7 +79,7 @@ parseRegName' = RegName.unsafeFromString <<< NES.join1With "" <$> NEA.some p
 -- |
 -- | As a counterpart to the `parser` this function also requires the `Host`
 -- | and `Port` components to be printed back from their custom representations.
--- | If no custom types are being used, pass `id` for both of these arguments.
+-- | If no custom types are being used, pass `identity` for both of these arguments.
 print
   ∷ ∀ host port
   . (host → Host)

--- a/src/URI/Extra/QueryPairs.purs
+++ b/src/URI/Extra/QueryPairs.purs
@@ -87,7 +87,7 @@ parsePart parseK parseV = do
 -- |
 -- | As a counterpart to the `parser` this function also requires the `Key`
 -- | and `Value` components to be printed back from their custom representations.
--- | If no custom types are being used, pass `id` for both of these arguments.
+-- | If no custom types are being used, pass `identity` for both of these arguments.
 print
   ∷ ∀ k v
   . (k → Key)

--- a/src/URI/HostPortPair.purs
+++ b/src/URI/HostPortPair.purs
@@ -48,7 +48,7 @@ parser parseHost parsePort = do
 -- |
 -- | As a counterpart to the `parser` this function also requires the `Host`
 -- | and `Port` components to be printed back from their custom representations.
--- | If no custom types are being used, pass `id` for both of these arguments.
+-- | If no custom types are being used, pass `identity` for both of these arguments.
 print
   ∷ ∀ host port
   . (host → Host)

--- a/src/URI/RelativeRef.purs
+++ b/src/URI/RelativeRef.purs
@@ -77,9 +77,9 @@ type RelativeRefParseOptions userInfo hosts path relPath query fragment r =
 -- | printer.
 -- |
 -- | As a reverse of the parse options, this specifies how to print values back
--- | from custom representations. If this is not necessary, `id` can be used for
+-- | from custom representations. If this is not necessary, `identity` can be used for
 -- | all the options aside from `printHosts`, which will typically be
--- | `HostPortPair.printHosts id id`. See [`URI.HostPortPair`](../URI.HostPortPair)
+-- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type RelativeRefPrintOptions userInfo hosts path relPath query fragment r =
   ( printUserInfo ∷ userInfo → UserInfo

--- a/src/URI/URI.purs
+++ b/src/URI/URI.purs
@@ -83,9 +83,9 @@ type URIParseOptions userInfo hosts path hierPath query fragment r =
 -- | when type anotating an options record.
 -- |
 -- | As a reverse of the parse options, this specifies how to print values back
--- | from custom representations. If this is not necessary, `id` can be used for
+-- | from custom representations. If this is not necessary, `identity` can be used for
 -- | all the options aside from `printHosts`, which will typically be
--- | `HostPortPair.printHosts id id`. See [`URI.HostPortPair`](../URI.HostPortPair)
+-- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type URIPrintOptions userInfo hosts path hierPath query fragment r =
   ( printUserInfo ∷ userInfo → UserInfo


### PR DESCRIPTION
Addresses #51 by replacing all instances of `id` in the documentation with `identity`.