### PR TITLE
Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ spago install uri
 
 ## Quick start
 
-The quick start hasn't been written yet (contributions are welcome!). The quick start covers a common, minimal use case for the library, whereas longer examples and tutorials are kept in the [docs directory](./docs.)
+The quick start hasn't been written yet (contributions are welcome!). The quick start covers a common, minimal use case for the library, whereas longer examples and tutorials are kept in the [docs directory](./docs).
 
 ## Documentation
 


### PR DESCRIPTION
This PR fixes a broken link to the docs that I noticed while going through the README.