### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 - Made all parsers stack safe on long input (#63 by @garyb)
 
 Other improvements:
+- Added `purs-tidy` formatter (#66 by @thomashoneyman)
 
 ## [v8.0.1](https://github.com/purescript-contrib/purescript-uri/releases/tag/v8.0.1) - 2021-05-06
 

--- a/src/URI/AbsoluteURI.purs
+++ b/src/URI/AbsoluteURI.purs
@@ -37,10 +37,11 @@ import URI.Scheme as Scheme
 -- | but is required to have a `Scheme` component.
 data AbsoluteURI userInfo hosts path hierPath query = AbsoluteURI Scheme (HierarchicalPart userInfo hosts path hierPath) (Maybe query)
 
-derive instance eqAbsoluteURI ∷ (Eq userInfo, Eq hosts, Eq path, Eq hierPath, Eq query) ⇒ Eq (AbsoluteURI userInfo hosts path hierPath query)
-derive instance ordAbsoluteURI ∷ (Ord userInfo, Ord hosts, Ord path, Ord hierPath, Ord query) ⇒ Ord (AbsoluteURI userInfo hosts path hierPath query)
-derive instance genericAbsoluteURI ∷ Generic (AbsoluteURI userInfo hosts path hierPath query) _
-instance showAbsoluteURI ∷ (Show userInfo, Show hosts, Show path, Show hierPath, Show query) ⇒ Show (AbsoluteURI userInfo hosts path hierPath query) where show = genericShow
+derive instance eqAbsoluteURI :: (Eq userInfo, Eq hosts, Eq path, Eq hierPath, Eq query) => Eq (AbsoluteURI userInfo hosts path hierPath query)
+derive instance ordAbsoluteURI :: (Ord userInfo, Ord hosts, Ord path, Ord hierPath, Ord query) => Ord (AbsoluteURI userInfo hosts path hierPath query)
+derive instance genericAbsoluteURI :: Generic (AbsoluteURI userInfo hosts path hierPath query) _
+instance showAbsoluteURI :: (Show userInfo, Show hosts, Show path, Show hierPath, Show query) => Show (AbsoluteURI userInfo hosts path hierPath query) where
+  show = genericShow
 
 -- | A row type for describing the options fields used by the absolute URI
 -- | parser and printer.
@@ -65,11 +66,11 @@ type AbsoluteURIOptions userInfo hosts path hierPath query =
 -- | `HostPortPair.parseHosts pure pure`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair parser.
 type AbsoluteURIParseOptions userInfo hosts path hierPath query r =
-  ( parseUserInfo ∷ UserInfo → Either URIPartParseError userInfo
-  , parseHosts ∷ Parser String hosts
-  , parsePath ∷ Path → Either URIPartParseError path
-  , parseHierPath ∷ Either PathAbsolute PathRootless → Either URIPartParseError hierPath
-  , parseQuery ∷ Query → Either URIPartParseError query
+  ( parseUserInfo :: UserInfo -> Either URIPartParseError userInfo
+  , parseHosts :: Parser String hosts
+  , parsePath :: Path -> Either URIPartParseError path
+  , parseHierPath :: Either PathAbsolute PathRootless -> Either URIPartParseError hierPath
+  , parseQuery :: Query -> Either URIPartParseError query
   | r
   )
 
@@ -85,19 +86,19 @@ type AbsoluteURIParseOptions userInfo hosts path hierPath query r =
 -- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type AbsoluteURIPrintOptions userInfo hosts path hierPath query r =
-  ( printUserInfo ∷ userInfo → UserInfo
-  , printHosts ∷ hosts → String
-  , printPath ∷ path → Path
-  , printHierPath ∷ hierPath → Either PathAbsolute PathRootless
-  , printQuery ∷ query → Query
+  ( printUserInfo :: userInfo -> UserInfo
+  , printHosts :: hosts -> String
+  , printPath :: path -> Path
+  , printHierPath :: hierPath -> Either PathAbsolute PathRootless
+  , printQuery :: query -> Query
   | r
   )
 
 -- | A parser for an absolute URI.
 parser
-  ∷ ∀ userInfo hosts path hierPath query r
-  . Record (AbsoluteURIParseOptions userInfo hosts path hierPath query r)
-  → Parser String (AbsoluteURI userInfo hosts path hierPath query)
+  :: forall userInfo hosts path hierPath query r
+   . Record (AbsoluteURIParseOptions userInfo hosts path hierPath query r)
+  -> Parser String (AbsoluteURI userInfo hosts path hierPath query)
 parser opts = AbsoluteURI
   <$> Scheme.parser
   <*> HPart.parser opts
@@ -106,10 +107,10 @@ parser opts = AbsoluteURI
 
 -- | A printer for an absolute URI.
 print
-  ∷ ∀ userInfo hosts path hierPath query r
-  . Record (AbsoluteURIPrintOptions userInfo hosts path hierPath query r)
-  → AbsoluteURI userInfo hosts path hierPath query
-  → String
+  :: forall userInfo hosts path hierPath query r
+   . Record (AbsoluteURIPrintOptions userInfo hosts path hierPath query r)
+  -> AbsoluteURI userInfo hosts path hierPath query
+  -> String
 print opts (AbsoluteURI s h q) =
   String.joinWith "" $ Array.catMaybes
     [ Just (Scheme.print s)
@@ -119,33 +120,33 @@ print opts (AbsoluteURI s h q) =
 
 -- | The scheme component of an absolute URI.
 _scheme
-  ∷ ∀ userInfo hosts path hierPath query
-  . Lens'
-      (AbsoluteURI userInfo hosts path hierPath query)
-      Scheme
+  :: forall userInfo hosts path hierPath query
+   . Lens'
+       (AbsoluteURI userInfo hosts path hierPath query)
+       Scheme
 _scheme =
   lens
-    (\(AbsoluteURI s _ _) → s)
-    (\(AbsoluteURI _ h q) s → AbsoluteURI s h q)
+    (\(AbsoluteURI s _ _) -> s)
+    (\(AbsoluteURI _ h q) s -> AbsoluteURI s h q)
 
 -- | The hierarchical-part component of an absolute URI.
 _hierPart
-  ∷ ∀ userInfo hosts path hierPath query
-  . Lens'
-      (AbsoluteURI userInfo hosts path hierPath query)
-      (HierarchicalPart userInfo hosts path hierPath)
+  :: forall userInfo hosts path hierPath query
+   . Lens'
+       (AbsoluteURI userInfo hosts path hierPath query)
+       (HierarchicalPart userInfo hosts path hierPath)
 _hierPart =
   lens
-    (\(AbsoluteURI _ h _) → h)
-    (\(AbsoluteURI s _ q) h → AbsoluteURI s h q)
+    (\(AbsoluteURI _ h _) -> h)
+    (\(AbsoluteURI s _ q) h -> AbsoluteURI s h q)
 
 -- | The query component of an absolute URI.
 _query
-  ∷ ∀ userInfo hosts path hierPath query
-  . Lens'
-      (AbsoluteURI userInfo hosts path hierPath query)
-      (Maybe query)
+  :: forall userInfo hosts path hierPath query
+   . Lens'
+       (AbsoluteURI userInfo hosts path hierPath query)
+       (Maybe query)
 _query =
   lens
-    (\(AbsoluteURI _ _ q) → q)
-    (\(AbsoluteURI s h _) q → AbsoluteURI s h q)
+    (\(AbsoluteURI _ _ q) -> q)
+    (\(AbsoluteURI s h _) q -> AbsoluteURI s h q)

--- a/src/URI/AbsoluteURI.purs
+++ b/src/URI/AbsoluteURI.purs
@@ -40,6 +40,7 @@ data AbsoluteURI userInfo hosts path hierPath query = AbsoluteURI Scheme (Hierar
 derive instance eqAbsoluteURI :: (Eq userInfo, Eq hosts, Eq path, Eq hierPath, Eq query) => Eq (AbsoluteURI userInfo hosts path hierPath query)
 derive instance ordAbsoluteURI :: (Ord userInfo, Ord hosts, Ord path, Ord hierPath, Ord query) => Ord (AbsoluteURI userInfo hosts path hierPath query)
 derive instance genericAbsoluteURI :: Generic (AbsoluteURI userInfo hosts path hierPath query) _
+
 instance showAbsoluteURI :: (Show userInfo, Show hosts, Show path, Show hierPath, Show query) => Show (AbsoluteURI userInfo hosts path hierPath query) where
   show = genericShow
 
@@ -99,11 +100,12 @@ parser
   :: forall userInfo hosts path hierPath query r
    . Record (AbsoluteURIParseOptions userInfo hosts path hierPath query r)
   -> Parser String (AbsoluteURI userInfo hosts path hierPath query)
-parser opts = AbsoluteURI
-  <$> Scheme.parser
-  <*> HPart.parser opts
-  <*> optionMaybe (wrapParser opts.parseQuery Query.parser)
-  <* eof
+parser opts =
+  AbsoluteURI
+    <$> Scheme.parser
+    <*> HPart.parser opts
+    <*> optionMaybe (wrapParser opts.parseQuery Query.parser)
+    <* eof
 
 -- | A printer for an absolute URI.
 print
@@ -119,33 +121,21 @@ print opts (AbsoluteURI s h q) =
     ]
 
 -- | The scheme component of an absolute URI.
-_scheme
-  :: forall userInfo hosts path hierPath query
-   . Lens'
-       (AbsoluteURI userInfo hosts path hierPath query)
-       Scheme
+_scheme :: forall userInfo hosts path hierPath query. Lens' (AbsoluteURI userInfo hosts path hierPath query) Scheme
 _scheme =
   lens
     (\(AbsoluteURI s _ _) -> s)
     (\(AbsoluteURI _ h q) s -> AbsoluteURI s h q)
 
 -- | The hierarchical-part component of an absolute URI.
-_hierPart
-  :: forall userInfo hosts path hierPath query
-   . Lens'
-       (AbsoluteURI userInfo hosts path hierPath query)
-       (HierarchicalPart userInfo hosts path hierPath)
+_hierPart :: forall userInfo hosts path hierPath query. Lens' (AbsoluteURI userInfo hosts path hierPath query) (HierarchicalPart userInfo hosts path hierPath)
 _hierPart =
   lens
     (\(AbsoluteURI _ h _) -> h)
     (\(AbsoluteURI s _ q) h -> AbsoluteURI s h q)
 
 -- | The query component of an absolute URI.
-_query
-  :: forall userInfo hosts path hierPath query
-   . Lens'
-       (AbsoluteURI userInfo hosts path hierPath query)
-       (Maybe query)
+_query :: forall userInfo hosts path hierPath query. Lens' (AbsoluteURI userInfo hosts path hierPath query) (Maybe query)
 _query =
   lens
     (\(AbsoluteURI _ _ q) -> q)

--- a/src/URI/Authority.purs
+++ b/src/URI/Authority.purs
@@ -32,10 +32,11 @@ import URI.UserInfo as UserInfo
 -- | `localhost:3000`, `user@example.net`.
 data Authority userInfo hosts = Authority (Maybe userInfo) hosts
 
-derive instance eqAuthority ∷ (Eq userInfo, Eq hosts) ⇒ Eq (Authority userInfo hosts)
-derive instance ordAuthority ∷ (Ord userInfo, Ord hosts) ⇒ Ord (Authority userInfo hosts)
-derive instance genericAuthority ∷ Generic (Authority userInfo hosts) _
-instance showAuthority ∷ (Show userInfo, Show hosts) ⇒ Show (Authority userInfo hosts) where show = genericShow
+derive instance eqAuthority :: (Eq userInfo, Eq hosts) => Eq (Authority userInfo hosts)
+derive instance ordAuthority :: (Ord userInfo, Ord hosts) => Ord (Authority userInfo hosts)
+derive instance genericAuthority :: Generic (Authority userInfo hosts) _
+instance showAuthority :: (Show userInfo, Show hosts) => Show (Authority userInfo hosts) where
+  show = genericShow
 
 -- | A row type for describing the options fields used by the authority parser
 -- | and printer.
@@ -51,8 +52,8 @@ type AuthorityOptions userInfo hosts =
 -- | Used as `Record (AuthorityParseOptions userInfo hosts ())` when type
 -- | annotating an options record.
 type AuthorityParseOptions userInfo hosts r =
-  ( parseUserInfo ∷ UserInfo → Either URIPartParseError userInfo
-  , parseHosts ∷ Parser String hosts
+  ( parseUserInfo :: UserInfo -> Either URIPartParseError userInfo
+  , parseHosts :: Parser String hosts
   | r
   )
 
@@ -61,52 +62,52 @@ type AuthorityParseOptions userInfo hosts r =
 -- | Used as `Record (AuthorityPrintOptions userInfo hosts ())` when type
 -- | annotating an options record.
 type AuthorityPrintOptions userInfo hosts r =
-  ( printUserInfo ∷ userInfo → UserInfo
-  , printHosts ∷ hosts → String
+  ( printUserInfo :: userInfo -> UserInfo
+  , printHosts :: hosts -> String
   | r
   )
 
 -- | A parser for the authority part of a URI. Expects values with a `"//"`
 -- | prefix.
 parser
-  ∷ ∀ userInfo hosts r
-  . Record (AuthorityParseOptions userInfo hosts r)
-  → Parser String (Authority userInfo hosts)
+  :: forall userInfo hosts r
+   . Record (AuthorityParseOptions userInfo hosts r)
+  -> Parser String (Authority userInfo hosts)
 parser opts = do
-  _ ← string "//"
-  ui ← optionMaybe $ try (wrapParser opts.parseUserInfo UserInfo.parser <* char '@')
-  hosts ← opts.parseHosts
+  _ <- string "//"
+  ui <- optionMaybe $ try (wrapParser opts.parseUserInfo UserInfo.parser <* char '@')
+  hosts <- opts.parseHosts
   pure $ Authority ui hosts
 
 -- | A printer for the authority part of a URI. Will print the value with a
 -- | `"//"` prefix.
 print
-  ∷ ∀ userInfo hosts r
-  . Record (AuthorityPrintOptions userInfo hosts r)
-  → Authority userInfo hosts
-  → String
+  :: forall userInfo hosts r
+   . Record (AuthorityPrintOptions userInfo hosts r)
+  -> Authority userInfo hosts
+  -> String
 print opts (Authority mui hs) = case mui of
-  Just ui → "//" <> UserInfo.print (opts.printUserInfo ui) <> "@" <> opts.printHosts hs
-  Nothing → "//" <> opts.printHosts hs
+  Just ui -> "//" <> UserInfo.print (opts.printUserInfo ui) <> "@" <> opts.printHosts hs
+  Nothing -> "//" <> opts.printHosts hs
 
 -- | A lens for the user-info component of the authority.
 _userInfo
-  ∷ ∀ userInfo hosts
-  . Lens'
-      (Authority userInfo hosts)
-      (Maybe userInfo)
+  :: forall userInfo hosts
+   . Lens'
+       (Authority userInfo hosts)
+       (Maybe userInfo)
 _userInfo =
   lens
-    (\(Authority ui _) → ui)
-    (\(Authority _ hs) ui → Authority ui hs)
+    (\(Authority ui _) -> ui)
+    (\(Authority _ hs) ui -> Authority ui hs)
 
 -- | A lens for the host(s) component of the authority.
 _hosts
-  ∷ ∀ userInfo hosts
-  . Lens'
-      (Authority userInfo hosts)
-      hosts
+  :: forall userInfo hosts
+   . Lens'
+       (Authority userInfo hosts)
+       hosts
 _hosts =
   lens
-    (\(Authority _ hs) → hs)
-    (\(Authority ui _) hs → Authority ui hs)
+    (\(Authority _ hs) -> hs)
+    (\(Authority ui _) hs -> Authority ui hs)

--- a/src/URI/Authority.purs
+++ b/src/URI/Authority.purs
@@ -35,6 +35,7 @@ data Authority userInfo hosts = Authority (Maybe userInfo) hosts
 derive instance eqAuthority :: (Eq userInfo, Eq hosts) => Eq (Authority userInfo hosts)
 derive instance ordAuthority :: (Ord userInfo, Ord hosts) => Ord (Authority userInfo hosts)
 derive instance genericAuthority :: Generic (Authority userInfo hosts) _
+
 instance showAuthority :: (Show userInfo, Show hosts) => Show (Authority userInfo hosts) where
   show = genericShow
 
@@ -91,22 +92,14 @@ print opts (Authority mui hs) = case mui of
   Nothing -> "//" <> opts.printHosts hs
 
 -- | A lens for the user-info component of the authority.
-_userInfo
-  :: forall userInfo hosts
-   . Lens'
-       (Authority userInfo hosts)
-       (Maybe userInfo)
+_userInfo :: forall userInfo hosts. Lens' (Authority userInfo hosts) (Maybe userInfo)
 _userInfo =
   lens
     (\(Authority ui _) -> ui)
     (\(Authority _ hs) ui -> Authority ui hs)
 
 -- | A lens for the host(s) component of the authority.
-_hosts
-  :: forall userInfo hosts
-   . Lens'
-       (Authority userInfo hosts)
-       hosts
+_hosts :: forall userInfo hosts. Lens' (Authority userInfo hosts) hosts
 _hosts =
   lens
     (\(Authority _ hs) -> hs)

--- a/src/URI/Common.purs
+++ b/src/URI/Common.purs
@@ -40,6 +40,7 @@ derive newtype instance eqURIPartParseError :: Eq URIPartParseError
 derive newtype instance ordURIPartParseError :: Ord URIPartParseError
 derive instance newtypeURIPartParseError :: Newtype URIPartParseError _
 derive instance genericURIPartParseError :: Generic URIPartParseError _
+
 instance showURIPartParseError :: Show URIPartParseError where
   show = genericShow
 

--- a/src/URI/Common.purs
+++ b/src/URI/Common.purs
@@ -40,47 +40,48 @@ derive newtype instance eqURIPartParseError :: Eq URIPartParseError
 derive newtype instance ordURIPartParseError :: Ord URIPartParseError
 derive instance newtypeURIPartParseError :: Newtype URIPartParseError _
 derive instance genericURIPartParseError :: Generic URIPartParseError _
-instance showURIPartParseError :: Show URIPartParseError where show = genericShow
+instance showURIPartParseError :: Show URIPartParseError where
+  show = genericShow
 
 -- | Adapts a parser with a parser-esque function. First the original
 -- | parser runs, then it attempts to refine the result with the function.
 wrapParser
-  ∷ ∀ s m a b
-  . Monad m
-  ⇒ (a → Either URIPartParseError b)
-  → ParserT s m a
-  → ParserT s m b
+  :: forall s m a b
+   . Monad m
+  => (a -> Either URIPartParseError b)
+  -> ParserT s m a
+  -> ParserT s m b
 wrapParser parseA p = ParserT do
-  ParseState _ pos _ ← get
-  a ← un ParserT p
+  ParseState _ pos _ <- get
+  a <- un ParserT p
   case parseA a of
-    Left (URIPartParseError err) → throwError (ParseError err pos)
-    Right b → pure b
+    Left (URIPartParseError err) -> throwError (ParseError err pos)
+    Right b -> pure b
 
 -- | Parser for ascii alphabetical characters (upper and lowercase).
-alpha ∷ Parser String Char
-alpha = satisfy \c → (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+alpha :: Parser String Char
+alpha = satisfy \c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 
 -- | Parser for ascii alphanumeric characters (upper and lowercase for letters).
-alphaNum ∷ Parser String Char
+alphaNum :: Parser String Char
 alphaNum = alpha <|> digit
 
 -- | Parser for characters that are allowed in a URI but do not have a reserved
 -- | purpose.
-unreserved ∷ Parser String Char
+unreserved :: Parser String Char
 unreserved = alphaNum <|> char '-' <|> char '.' <|> char '_' <|> char '~'
 
 -- | Parser for the "sub-delims" group of reserved characters.
-subDelims ∷ Parser String Char
+subDelims :: Parser String Char
 subDelims =
-  oneOf ['!', '$', '&', '\'', '(', ')', '*', '+', ';', '=', ',']
+  oneOf [ '!', '$', '&', '\'', '(', ')', '*', '+', ';', '=', ',' ]
 
 -- | Parser for a percent-encoded character.
-pctEncoded ∷ Parser String NonEmptyString
+pctEncoded :: Parser String NonEmptyString
 pctEncoded = do
-  d0 ← char '%'
-  d1 ← hexDigit
-  d2 ← hexDigit
+  d0 <- char '%'
+  d1 <- hexDigit
+  d2 <- hexDigit
   pure $ NES.singleton d0 <> NES.singleton d1 <> NES.singleton d2
 
 -- | A helper function for printing URI components using percent-encoding for
@@ -88,24 +89,26 @@ pctEncoded = do
 -- |
 -- | Accepts a parser that is used to determine whether a character is allowed
 -- | to appear un-encoded in the URI component and the string to encode.
-printEncoded ∷ Parser String Char → String → String
+printEncoded :: Parser String Char -> String -> String
 printEncoded p s = either (const s) identity (runParser s parse)
   where
-    parse ∷ Parser String String
-    parse = (NES.joinWith "" <$> List.manyRec (simpleChar <|> encodedChar)) <* eof
-    simpleChar ∷ Parser String NonEmptyString
-    simpleChar = NES.singleton <$> p
-    encodedChar ∷ Parser String NonEmptyString
-    encodedChar = unsafePartial (NES.unsafeFromString <<< fromJust) <<< encodeURIComponent <<< String.singleton <$> anyChar
+  parse :: Parser String String
+  parse = (NES.joinWith "" <$> List.manyRec (simpleChar <|> encodedChar)) <* eof
+
+  simpleChar :: Parser String NonEmptyString
+  simpleChar = NES.singleton <$> p
+
+  encodedChar :: Parser String NonEmptyString
+  encodedChar = unsafePartial (NES.unsafeFromString <<< fromJust) <<< encodeURIComponent <<< String.singleton <$> anyChar
 
 -- | A version of [`printEncoded`](#v:printEncoded) that operates on non-empty
 -- | strings.
-printEncoded' ∷ Parser String Char → NonEmptyString → NonEmptyString
+printEncoded' :: Parser String Char -> NonEmptyString -> NonEmptyString
 printEncoded' p =
   unsafePartial NES.unsafeFromString <<< printEncoded p <<< NES.toString
 
 -- | A version of [`decodeURIComponent`](https://pursuit.purescript.org/packages/purescript-jsuri/docs/JSURI#v:decodeURIComponent)
 -- | that operates on non-empty strings.
-decodeURIComponent' ∷ NonEmptyString → NonEmptyString
+decodeURIComponent' :: NonEmptyString -> NonEmptyString
 decodeURIComponent' =
   unsafePartial NES.unsafeFromString <<< unsafePartial fromJust <<< decodeURIComponent <<< NES.toString

--- a/src/URI/Extra/MultiHostPortPair.purs
+++ b/src/URI/Extra/MultiHostPortPair.purs
@@ -64,10 +64,10 @@ parsePair parseHost parsePort = do
     Nothing, Nothing -> fail "Neither host nor port present"
 
 parseHost' :: forall h. (Host -> Either URIPartParseError h) -> Parser String h
-parseHost' p = wrapParser p
-  $ (IPv6Address <$> IPv6Address.parser)
-      <|> try (IPv4Address <$> IPv4Address.parser)
-      <|> (NameAddress <$> parseRegName')
+parseHost' p = wrapParser p do
+  (IPv6Address <$> IPv6Address.parser)
+    <|> try (IPv4Address <$> IPv4Address.parser)
+    <|> (NameAddress <$> parseRegName')
 
 parseRegName' :: Parser String RegName
 parseRegName' = RegName.unsafeFromString <<< NES.join1With "" <$> NEA.some p

--- a/src/URI/Extra/QueryPairs.purs
+++ b/src/URI/Extra/QueryPairs.purs
@@ -49,14 +49,14 @@ import URI.Query as Q
 -- | - `&` and `;` are both treated as pair delimiters.
 newtype QueryPairs k v = QueryPairs (Array (Tuple k (Maybe v)))
 
+derive instance genericQueryPairs :: Generic (QueryPairs k v) _
 derive newtype instance eqQueryPairs :: (Eq k, Eq v) => Eq (QueryPairs k v)
 derive newtype instance ordQueryPairs :: (Ord k, Ord v) => Ord (QueryPairs k v)
-derive instance genericQueryPairs :: Generic (QueryPairs k v) _
-instance showQueryPairs :: (Show k, Show v) => Show (QueryPairs k v) where
-  show = genericShow
-
 derive newtype instance semigroupQueryPairs :: Semigroup (QueryPairs k v)
 derive newtype instance monoidQueryPairs :: Monoid (QueryPairs k v)
+
+instance showQueryPairs :: (Show k, Show v) => Show (QueryPairs k v) where
+  show = genericShow
 
 -- | Parses a query into key/value pairs.
 -- |
@@ -209,8 +209,9 @@ unsafeValueToString (Value s) = s
 
 -- | The supported key characters, excluding percent-encodings.
 keyPartChar :: Parser String Char
-keyPartChar = unreserved
-  <|> oneOf [ '!', '$', '\'', '(', ')', '*', '+', ',', ':', '@', '/', '?' ]
+keyPartChar =
+  unreserved
+    <|> oneOf [ '!', '$', '\'', '(', ')', '*', '+', ',', ':', '@', '/', '?' ]
 
 -- | The supported value characters, excluding percent-encodings.
 valuePartChar :: Parser String Char

--- a/src/URI/Extra/QueryPairs.purs
+++ b/src/URI/Extra/QueryPairs.purs
@@ -49,12 +49,14 @@ import URI.Query as Q
 -- | - `&` and `;` are both treated as pair delimiters.
 newtype QueryPairs k v = QueryPairs (Array (Tuple k (Maybe v)))
 
-derive newtype instance eqQueryPairs ∷ (Eq k, Eq v) ⇒ Eq (QueryPairs k v)
-derive newtype instance ordQueryPairs ∷ (Ord k, Ord v) ⇒ Ord (QueryPairs k v)
-derive instance genericQueryPairs ∷ Generic (QueryPairs k v) _
-instance showQueryPairs ∷ (Show k, Show v) ⇒ Show (QueryPairs k v) where show = genericShow
-derive newtype instance semigroupQueryPairs ∷ Semigroup (QueryPairs k v)
-derive newtype instance monoidQueryPairs ∷ Monoid (QueryPairs k v)
+derive newtype instance eqQueryPairs :: (Eq k, Eq v) => Eq (QueryPairs k v)
+derive newtype instance ordQueryPairs :: (Ord k, Ord v) => Ord (QueryPairs k v)
+derive instance genericQueryPairs :: Generic (QueryPairs k v) _
+instance showQueryPairs :: (Show k, Show v) => Show (QueryPairs k v) where
+  show = genericShow
+
+derive newtype instance semigroupQueryPairs :: Semigroup (QueryPairs k v)
+derive newtype instance monoidQueryPairs :: Monoid (QueryPairs k v)
 
 -- | Parses a query into key/value pairs.
 -- |
@@ -62,26 +64,26 @@ derive newtype instance monoidQueryPairs ∷ Monoid (QueryPairs k v)
 -- | into custom representations. If this is not necessary, use `pure` for both
 -- | these arguments.
 parse
-  ∷ ∀ k v
-  . (Key → Either URIPartParseError k)
-  → (Value → Either URIPartParseError v)
-  → Q.Query
-  → Either URIPartParseError (QueryPairs k v)
+  :: forall k v
+   . (Key -> Either URIPartParseError k)
+  -> (Value -> Either URIPartParseError v)
+  -> Q.Query
+  -> Either URIPartParseError (QueryPairs k v)
 parse parseK parseV =
-  bimap (\(ParseError err _) → URIPartParseError err) QueryPairs
+  bimap (\(ParseError err _) -> URIPartParseError err) QueryPairs
     <<< flip runParser (Array.fromFoldable <$> sepBy (parsePart parseK parseV) (char '&'))
     <<< Q.unsafeToString
 
 parsePart
-  ∷ ∀ k v
-  . (Key → Either URIPartParseError k)
-  → (Value → Either URIPartParseError v)
-  → Parser String (Tuple k (Maybe v))
+  :: forall k v
+   . (Key -> Either URIPartParseError k)
+  -> (Value -> Either URIPartParseError v)
+  -> Parser String (Tuple k (Maybe v))
 parsePart parseK parseV = do
-  key ← wrapParser (parseK <<< Key) $
+  key <- wrapParser (parseK <<< Key) $
     NES.joinWith "" <$> List.someRec (NES.singleton <$> keyPartChar <|> pctEncoded)
-  value ← wrapParser (traverse (parseV <<< Value)) $ optionMaybe do
-    _ ← char '='
+  value <- wrapParser (traverse (parseV <<< Value)) $ optionMaybe do
+    _ <- char '='
     NES.joinWith "" <$> List.manyRec (NES.singleton <$> valuePartChar <|> pctEncoded)
   pure $ Tuple key value
 
@@ -91,30 +93,30 @@ parsePart parseK parseV = do
 -- | and `Value` components to be printed back from their custom representations.
 -- | If no custom types are being used, pass `identity` for both of these arguments.
 print
-  ∷ ∀ k v
-  . (k → Key)
-  → (v → Value)
-  → QueryPairs k v
-  → Q.Query
+  :: forall k v
+   . (k -> Key)
+  -> (v -> Value)
+  -> QueryPairs k v
+  -> Q.Query
 print printK printV (QueryPairs m) =
   Q.unsafeFromString $ String.joinWith "&" $ Array.fromFoldable (printPart <$> m)
   where
-    printPart ∷ Tuple k (Maybe v) → String
-    printPart = case _ of
-      Tuple k Nothing →
-        unsafeKeyToString (printK k)
-      Tuple k (Just v) →
-        unsafeKeyToString (printK k) <> "=" <> unsafeValueToString (printV v)
+  printPart :: Tuple k (Maybe v) -> String
+  printPart = case _ of
+    Tuple k Nothing ->
+      unsafeKeyToString (printK k)
+    Tuple k (Just v) ->
+      unsafeKeyToString (printK k) <> "=" <> unsafeValueToString (printV v)
 
 -- | The default `Key` type used for `QueryPairs`.
 newtype Key = Key String
 
-derive newtype instance eqKey ∷ Eq Key
-derive newtype instance ordKey ∷ Ord Key
-derive newtype instance semigroupKey ∷ Semigroup Key
-derive newtype instance monoidKey ∷ Monoid Key
+derive newtype instance eqKey :: Eq Key
+derive newtype instance ordKey :: Ord Key
+derive newtype instance semigroupKey :: Semigroup Key
+derive newtype instance monoidKey :: Monoid Key
 
-instance showKey ∷ Show Key where
+instance showKey :: Show Key where
   show (Key s) = "(QueryPairs.unsafeKeyFromString " <> show s <> ")"
 
 -- | Constructs a key value from a string, percent-encoding any characters
@@ -127,7 +129,7 @@ instance showKey ∷ Show Key where
 -- | keyFromString "foo#bar" = unsafeKeyFromString "foo%23bar"
 -- | keyFromString "foo%23bar" = unsafeKeyFromString "foo%2523bar"
 -- | ```
-keyFromString ∷ String → Key
+keyFromString :: String -> Key
 keyFromString = Key <<< printEncoded keyPartChar
 
 -- | Returns the string value for a key, percent-decoding any characters
@@ -137,31 +139,31 @@ keyFromString = Key <<< printEncoded keyPartChar
 -- | keyToString (unsafeKeyFromString "foo") = "foo"
 -- | keyToString (unsafeKeyFromString "foo%23bar") = "foo#bar"
 -- | ```
-keyToString ∷ Key → String
+keyToString :: Key -> String
 keyToString (Key s) = unsafePartial $ fromJust $ decodeURIComponent s
 
 -- | Constructs a key value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the key, to prevent double-encoding.
-unsafeKeyFromString ∷ String → Key
+unsafeKeyFromString :: String -> Key
 unsafeKeyFromString = Key
 
 -- | Returns the string value for a key without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeKeyToString ∷ Key → String
+unsafeKeyToString :: Key -> String
 unsafeKeyToString (Key s) = s
 
 -- | The default `Value` type used for `QueryPairs`.
 newtype Value = Value String
 
-derive newtype instance eqValue ∷ Eq Value
-derive newtype instance ordValue ∷ Ord Value
-derive newtype instance semigroupValue ∷ Semigroup Value
-derive newtype instance monoidValue ∷ Monoid Value
+derive newtype instance eqValue :: Eq Value
+derive newtype instance ordValue :: Ord Value
+derive newtype instance semigroupValue :: Semigroup Value
+derive newtype instance monoidValue :: Monoid Value
 
-instance showValue ∷ Show Value where
+instance showValue :: Show Value where
   show (Value s) = "(QueryPairs.unsafeValueFromString " <> show s <> ")"
 
 -- | Constructs a value from a string, percent-encoding any characters
@@ -174,7 +176,7 @@ instance showValue ∷ Show Value where
 -- | valueFromString "foo#bar" = unsafeValueFromString "foo%23bar"
 -- | valueFromString "foo%23bar" = unsafeValueFromString "foo%2523bar"
 -- | ```
-valueFromString ∷ String → Value
+valueFromString :: String -> Value
 valueFromString =
   -- `keyPartChar` is used intentionally here. It only differs from
   -- `valuePartChar` by excluding `=`, and `=` should be encoded as `%3D`, but
@@ -189,28 +191,27 @@ valueFromString =
 -- | valueToString (unsafeValueFromString "foo") = "foo"
 -- | valueToString (unsafeValueFromString "foo%23bar") = "foo#bar"
 -- | ```
-valueToString ∷ Value → String
+valueToString :: Value -> String
 valueToString (Value s) = unsafePartial $ fromJust $ decodeURIComponent s
 
 -- | Constructs a value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the value, to prevent double-encoding.
-unsafeValueFromString ∷ String → Value
+unsafeValueFromString :: String -> Value
 unsafeValueFromString = Value
 
 -- | Returns the string value for a value without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeValueToString ∷ Value → String
+unsafeValueToString :: Value -> String
 unsafeValueToString (Value s) = s
 
 -- | The supported key characters, excluding percent-encodings.
-keyPartChar ∷ Parser String Char
-keyPartChar
-  = unreserved
-  <|> oneOf ['!', '$', '\'', '(', ')', '*', '+', ',', ':', '@', '/', '?']
+keyPartChar :: Parser String Char
+keyPartChar = unreserved
+  <|> oneOf [ '!', '$', '\'', '(', ')', '*', '+', ',', ':', '@', '/', '?' ]
 
 -- | The supported value characters, excluding percent-encodings.
-valuePartChar ∷ Parser String Char
+valuePartChar :: Parser String Char
 valuePartChar = keyPartChar <|> char '='

--- a/src/URI/Extra/UserPassInfo.purs
+++ b/src/URI/Extra/UserPassInfo.purs
@@ -32,48 +32,48 @@ import URI.UserInfo as UserInfo
 -- | containing un-encoded `:` characters.
 newtype UserPassInfo =
   UserPassInfo
-    { user ∷ NonEmptyString
-    , password ∷ Maybe NonEmptyString
+    { user :: NonEmptyString
+    , password :: Maybe NonEmptyString
     }
 
-derive instance eqUserPassInfo ∷ Eq UserPassInfo
-derive instance ordUserPassInfo ∷ Ord UserPassInfo
-derive instance newtypeUserPassInfo ∷ Newtype UserPassInfo _
+derive instance eqUserPassInfo :: Eq UserPassInfo
+derive instance ordUserPassInfo :: Ord UserPassInfo
+derive instance newtypeUserPassInfo :: Newtype UserPassInfo _
 
-instance showUserPassInfo ∷ Show UserPassInfo where
+instance showUserPassInfo :: Show UserPassInfo where
   show (UserPassInfo { user, password }) =
     "(UserPassInfo { user: " <> show user <> ", password: " <> show password <> "})"
 
 -- | A parser for `user:password` formatted user-info.
-parse ∷ UserInfo → Either URIPartParseError UserPassInfo
+parse :: UserInfo -> Either URIPartParseError UserPassInfo
 parse ui =
   let
     s = UserInfo.unsafeToString ui
   in
     case flip NES.splitAt s <$> NES.indexOf (String.Pattern ":") s of
-      Just { before: Nothing } →
+      Just { before: Nothing } ->
         Left (URIPartParseError "Expected a username before a password segment")
-      Just { before: Just before, after: Just after } →
+      Just { before: Just before, after: Just after } ->
         Right $ UserPassInfo
           { user: decodeURIComponent' before
           , password: decodeURIComponent' <$> NES.drop 1 after
           }
-      _ →
+      _ ->
         Right $ UserPassInfo
           { user: decodeURIComponent' s, password: Nothing }
 
 -- | A printer for `user:password` formatted user-info.
-print ∷ UserPassInfo → UserInfo
+print :: UserPassInfo -> UserInfo
 print (UserPassInfo { user, password }) =
   case password of
-    Nothing →
+    Nothing ->
       UserInfo.unsafeFromString (printEncoded' userPassInfoChar user)
-    Just p →
+    Just p ->
       UserInfo.unsafeFromString
         $ printEncoded' userPassInfoChar user
-        <> NES.singleton ':'
-        <> printEncoded' userPassInfoChar p
+            <> NES.singleton ':'
+            <> printEncoded' userPassInfoChar p
 
 -- | The supported user/password characters, excluding percent-encodings.
-userPassInfoChar ∷ Parser String Char
+userPassInfoChar :: Parser String Char
 userPassInfoChar = unreserved <|> subDelims

--- a/src/URI/Extra/UserPassInfo.purs
+++ b/src/URI/Extra/UserPassInfo.purs
@@ -30,11 +30,10 @@ import URI.UserInfo as UserInfo
 -- | The `:` characer will be percent-encoded in all locations other than the
 -- | `user:password` separator, although the parser will accept passwords
 -- | containing un-encoded `:` characters.
-newtype UserPassInfo =
-  UserPassInfo
-    { user :: NonEmptyString
-    , password :: Maybe NonEmptyString
-    }
+newtype UserPassInfo = UserPassInfo
+  { user :: NonEmptyString
+  , password :: Maybe NonEmptyString
+  }
 
 derive instance eqUserPassInfo :: Eq UserPassInfo
 derive instance ordUserPassInfo :: Ord UserPassInfo
@@ -46,21 +45,21 @@ instance showUserPassInfo :: Show UserPassInfo where
 
 -- | A parser for `user:password` formatted user-info.
 parse :: UserInfo -> Either URIPartParseError UserPassInfo
-parse ui =
-  let
-    s = UserInfo.unsafeToString ui
-  in
-    case flip NES.splitAt s <$> NES.indexOf (String.Pattern ":") s of
-      Just { before: Nothing } ->
-        Left (URIPartParseError "Expected a username before a password segment")
-      Just { before: Just before, after: Just after } ->
-        Right $ UserPassInfo
-          { user: decodeURIComponent' before
-          , password: decodeURIComponent' <$> NES.drop 1 after
-          }
-      _ ->
-        Right $ UserPassInfo
-          { user: decodeURIComponent' s, password: Nothing }
+parse ui = do
+  let s = UserInfo.unsafeToString ui
+  case flip NES.splitAt s <$> NES.indexOf (String.Pattern ":") s of
+    Just { before: Nothing } ->
+      Left (URIPartParseError "Expected a username before a password segment")
+    Just { before: Just before, after: Just after } ->
+      Right $ UserPassInfo
+        { user: decodeURIComponent' before
+        , password: decodeURIComponent' <$> NES.drop 1 after
+        }
+    _ ->
+      Right $ UserPassInfo
+        { user: decodeURIComponent' s
+        , password: Nothing
+        }
 
 -- | A printer for `user:password` formatted user-info.
 print :: UserPassInfo -> UserInfo
@@ -69,10 +68,10 @@ print (UserPassInfo { user, password }) =
     Nothing ->
       UserInfo.unsafeFromString (printEncoded' userPassInfoChar user)
     Just p ->
-      UserInfo.unsafeFromString
-        $ printEncoded' userPassInfoChar user
-            <> NES.singleton ':'
-            <> printEncoded' userPassInfoChar p
+      UserInfo.unsafeFromString $
+        printEncoded' userPassInfoChar user
+          <> NES.singleton ':'
+          <> printEncoded' userPassInfoChar p
 
 -- | The supported user/password characters, excluding percent-encodings.
 userPassInfoChar :: Parser String Char

--- a/src/URI/Fragment.purs
+++ b/src/URI/Fragment.purs
@@ -25,12 +25,12 @@ import URI.Common (subDelims, unreserved, pctEncoded, printEncoded)
 -- | The fragment component (hash) of a URI.
 newtype Fragment = Fragment String
 
-derive newtype instance eqFragment ∷ Eq Fragment
-derive newtype instance ordFragment ∷ Ord Fragment
-derive newtype instance semigroupFragment ∷ Semigroup Fragment
-derive newtype instance monoidFragment ∷ Monoid Fragment
+derive newtype instance eqFragment :: Eq Fragment
+derive newtype instance ordFragment :: Ord Fragment
+derive newtype instance semigroupFragment :: Semigroup Fragment
+derive newtype instance monoidFragment :: Monoid Fragment
 
-instance showFragment ∷ Show Fragment where
+instance showFragment :: Show Fragment where
   show (Fragment s) = "(Fragment.unsafeFromString " <> show s <> ")"
 
 -- | Constructs a fragment value from a string, percent-encoding any characters
@@ -43,7 +43,7 @@ instance showFragment ∷ Show Fragment where
 -- | fromString "foo#bar" = unsafeFromString "foo%23bar"
 -- | fromString "foo%23bar" = unsafeFromString "foo%2523bar"
 -- | ```
-fromString ∷ String → Fragment
+fromString :: String -> Fragment
 fromString = Fragment <<< printEncoded fragmentChar
 
 -- | Returns the string value for a fragment, percent-decoding any characters
@@ -53,37 +53,41 @@ fromString = Fragment <<< printEncoded fragmentChar
 -- | toString (unsafeFromString "foo") = "foo"
 -- | toString (unsafeFromString "foo%23bar") = "foo#bar"
 -- | ```
-toString ∷ Fragment → String
+toString :: Fragment -> String
 toString (Fragment s) = unsafePartial $ fromJust $ decodeURIComponent s
 
 -- | Constructs a fragment value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the fragment, to prevent double-encoding.
-unsafeFromString ∷ String → Fragment
+unsafeFromString :: String -> Fragment
 unsafeFromString = Fragment
 
 -- | Returns the string value for the fragment without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeToString ∷ Fragment → String
+unsafeToString :: Fragment -> String
 unsafeToString (Fragment s) = s
 
 -- | A parser for the fragment component of a URI. Expects values with a `'#'`
 -- | prefix.
-parser ∷ Parser String Fragment
+parser :: Parser String Fragment
 parser =
   char '#' *>
-    (Fragment <<< NES.joinWith ""
-      <$> List.manyRec (pctEncoded <|> NES.singleton <$> fragmentChar))
+    ( Fragment <<< NES.joinWith ""
+        <$> List.manyRec (pctEncoded <|> NES.singleton <$> fragmentChar)
+    )
 
 -- | A printer for the fragment component of a URI. Will print the value with
 -- | a `'#'` prefix.
-print ∷ Fragment → String
+print :: Fragment -> String
 print (Fragment f) = "#" <> f
 
 -- | The supported fragment characters, excluding percent-encodings.
-fragmentChar ∷ Parser String Char
+fragmentChar :: Parser String Char
 fragmentChar =
   unreserved <|> subDelims
-    <|> char ':' <|> char '@' <|> char '/' <|> char '?'
+    <|> char ':'
+    <|> char '@'
+    <|> char '/'
+    <|> char '?'

--- a/src/URI/HierarchicalPart.purs
+++ b/src/URI/HierarchicalPart.purs
@@ -48,6 +48,7 @@ data HierarchicalPart userInfo hosts path hierPath
 derive instance eqHierarchicalPart :: (Eq userInfo, Eq hosts, Eq path, Eq hierPath) => Eq (HierarchicalPart userInfo hosts path hierPath)
 derive instance ordHierarchicalPart :: (Ord userInfo, Ord hosts, Ord path, Ord hierPath) => Ord (HierarchicalPart userInfo hosts path hierPath)
 derive instance genericHierarchicalPart :: Generic (HierarchicalPart userInfo hosts path hierPath) _
+
 instance showHierarchicalPart :: (Show userInfo, Show hosts, Show path, Show hierPath) => Show (HierarchicalPart userInfo hosts path hierPath) where
   show = genericShow
 
@@ -122,33 +123,21 @@ print opts = case _ of
     maybe "" (either PathAbs.print PathRootless.print <<< opts.printHierPath) p
 
 -- | An affine traversal for the authority component of a hierarchical-part.
-_authority
-  :: forall userInfo hosts path hierPath
-   . Traversal'
-       (HierarchicalPart userInfo hosts path hierPath)
-       (Authority userInfo hosts)
+_authority :: forall userInfo hosts path hierPath. Traversal' (HierarchicalPart userInfo hosts path hierPath) (Authority userInfo hosts)
 _authority = wander \f -> case _ of
   HierarchicalPartAuth a p -> flip HierarchicalPartAuth p <$> f a
   a -> pure a
 
 -- | An affine traversal for the path component of a hierarchical-part, this
 -- | succeeds when the authority is present also.
-_path
-  :: forall userInfo hosts path hierPath
-   . Traversal'
-       (HierarchicalPart userInfo hosts path hierPath)
-       path
+_path :: forall userInfo hosts path hierPath. Traversal' (HierarchicalPart userInfo hosts path hierPath) path
 _path = wander \f -> case _ of
   HierarchicalPartAuth a p -> HierarchicalPartAuth a <$> f p
   a -> pure a
 
 -- | An affine traversal for the path component of a hierarchical-part, this
 -- | succeeds when the authority is not present.
-_hierPath
-  :: forall userInfo hosts path hierPath
-   . Traversal'
-       (HierarchicalPart userInfo hosts path hierPath)
-       (Maybe hierPath)
+_hierPath :: forall userInfo hosts path hierPath. Traversal' (HierarchicalPart userInfo hosts path hierPath) (Maybe hierPath)
 _hierPath = wander \f -> case _ of
   HierarchicalPartNoAuth p -> HierarchicalPartNoAuth <$> f p
   a -> pure a

--- a/src/URI/Host.purs
+++ b/src/URI/Host.purs
@@ -32,39 +32,40 @@ data Host
   | IPv4Address IPv4Address
   | NameAddress RegName
 
-derive instance eqHost ∷ Eq Host
-derive instance ordHost ∷ Ord Host
-derive instance genericHost ∷ Generic Host _
-instance showHost ∷ Show Host where show = genericShow
+derive instance eqHost :: Eq Host
+derive instance ordHost :: Ord Host
+derive instance genericHost :: Generic Host _
+instance showHost :: Show Host where
+  show = genericShow
 
 -- | A parser for host addresses.
-parser ∷ Parser String Host
+parser :: Parser String Host
 parser =
   (IPv6Address <$> IPv6Address.parser)
     <|> try (IPv4Address <$> IPv4Address.parser)
     <|> (NameAddress <$> RegName.parser)
 
 -- | A printer for host addresses.
-print ∷ Host → String
+print :: Host -> String
 print = case _ of
-  IPv6Address addr → IPv6Address.unsafeToString addr
-  IPv4Address addr → IPv4Address.print addr
-  NameAddress addr → RegName.print addr
+  IPv6Address addr -> IPv6Address.unsafeToString addr
+  IPv4Address addr -> IPv4Address.print addr
+  NameAddress addr -> RegName.print addr
 
 -- | A prism for the `IPv6Address` constructor.
-_IPv6Address ∷ Prism' Host IPv6Address
+_IPv6Address :: Prism' Host IPv6Address
 _IPv6Address = prism' IPv6Address case _ of
-  IPv6Address addr → Just addr
-  _ → Nothing
+  IPv6Address addr -> Just addr
+  _ -> Nothing
 
 -- | A prism for the `IPv4Address` constructor.
-_IPv4Address ∷ Prism' Host IPv4Address
+_IPv4Address :: Prism' Host IPv4Address
 _IPv4Address = prism' IPv4Address case _ of
-  IPv4Address addr → Just addr
-  _ → Nothing
+  IPv4Address addr -> Just addr
+  _ -> Nothing
 
 -- | A prism for the `NameAddress` constructor.
-_NameAddress ∷ Prism' Host RegName
+_NameAddress :: Prism' Host RegName
 _NameAddress = prism' NameAddress case _ of
-  NameAddress addr → Just addr
-  _ → Nothing
+  NameAddress addr -> Just addr
+  _ -> Nothing

--- a/src/URI/Host/Gen.purs
+++ b/src/URI/Host/Gen.purs
@@ -12,23 +12,23 @@ import URI.Host.IPv4Address as IPv4Address
 import URI.Host.RegName as RegName
 
 -- | Generates a random `IPv4Address` for testing purposes.
-genIPv4 ∷ ∀ m. Gen.MonadGen m ⇒ m IPv4Address
+genIPv4 :: forall m. Gen.MonadGen m => m IPv4Address
 genIPv4 = do
-  a ← Gen.chooseInt 0 255
-  b ← Gen.chooseInt 0 255
-  c ← Gen.chooseInt 0 255
-  d ← Gen.chooseInt 0 255
+  a <- Gen.chooseInt 0 255
+  b <- Gen.chooseInt 0 255
+  c <- Gen.chooseInt 0 255
+  d <- Gen.chooseInt 0 255
   pure $ IPv4Address.unsafeFromInts a b c d
 
 -- | Generates a random `RegName` for testing purposes.
-genRegName ∷ ∀ m. Gen.MonadGen m ⇒ MonadRec m ⇒ m RegName
+genRegName :: forall m. Gen.MonadGen m => MonadRec m => m RegName
 genRegName = do
-  head ← genAlphaNumeric
-  tail ← GenString.genString genAlphaNumeric
+  head <- genAlphaNumeric
+  tail <- GenString.genString genAlphaNumeric
   pure $ RegName.fromString $ NES.cons head tail
   where
-    genAlphaNumeric = Gen.choose GenChar.genAlpha GenChar.genDigitChar
+  genAlphaNumeric = Gen.choose GenChar.genAlpha GenChar.genDigitChar
 
 -- | Generates a random `Host` for testing purposes.
-genHost ∷ ∀ m. Gen.MonadGen m ⇒ MonadRec m ⇒ m Host
+genHost :: forall m. Gen.MonadGen m => MonadRec m => m Host
 genHost = Gen.choose (NameAddress <$> genRegName) (IPv4Address <$> genIPv4)

--- a/src/URI/Host/IPv4Address.purs
+++ b/src/URI/Host/IPv4Address.purs
@@ -67,10 +67,10 @@ print (IPv4Address o1 o2 o3 o4) =
   show o1 <> "." <> show o2 <> "." <> show o3 <> "." <> show o4
 
 octet :: Parser String Int
-octet = wrapParser toInt
-  $ try ((\x y z -> String.fromCharArray [ x, y, z ]) <$> nzDigit <*> digit <*> digit)
-      <|> try ((\x y -> String.fromCharArray [ x, y ]) <$> nzDigit <*> digit)
-      <|> (String.singleton <$> digit)
+octet = wrapParser toInt $
+  try ((\x y z -> String.fromCharArray [ x, y, z ]) <$> nzDigit <*> digit <*> digit)
+    <|> try ((\x y -> String.fromCharArray [ x, y ]) <$> nzDigit <*> digit)
+    <|> (String.singleton <$> digit)
 
 nzDigit :: Parser String Char
 nzDigit = satisfy (\c -> c >= '1' && c <= '9')

--- a/src/URI/Host/IPv4Address.purs
+++ b/src/URI/Host/IPv4Address.purs
@@ -23,22 +23,22 @@ import URI.Common (URIPartParseError(..), wrapParser)
 -- | The IPv4 address variation of the host part of a URI.
 data IPv4Address = IPv4Address Int Int Int Int
 
-derive instance eqIPv4Address ∷ Eq IPv4Address
-derive instance ordIPv4Address ∷ Ord IPv4Address
+derive instance eqIPv4Address :: Eq IPv4Address
+derive instance ordIPv4Address :: Ord IPv4Address
 
-instance showIPv4Address ∷ Show IPv4Address where
+instance showIPv4Address :: Show IPv4Address where
   show (IPv4Address o1 o2 o3 o4) = "(IPv4Address.unsafeFromInts " <> show o1 <> " " <> show o2 <> " " <> show o3 <> " " <> show o4 <> ")"
 
 -- | Constructs a `IPv4Address` part safely: bounds-checks each octet to ensure
 -- | it occurs within the range 0-255 (inclusive).
-fromInts ∷ Int → Int → Int → Int → Maybe IPv4Address
+fromInts :: Int -> Int -> Int -> Int -> Maybe IPv4Address
 fromInts o1 o2 o3 o4 =
   IPv4Address <$> check o1 <*> check o2 <*> check o3 <*> check o4
   where
-    check ∷ Int → Maybe Int
-    check i
-      | i >= 0 && i <= 255 = Just i
-      | otherwise = Nothing
+  check :: Int -> Maybe Int
+  check i
+    | i >= 0 && i <= 255 = Just i
+    | otherwise = Nothing
 
 -- | Constructs a `IPv4Address` part unsafely: if any of the arguments are
 -- | outside the allowable bounds, a runtime error will be thrown.
@@ -46,36 +46,36 @@ fromInts o1 o2 o3 o4 =
 -- | This is intended as a convenience when describing `IPv4Address`es
 -- | statically in PureScript code, in all other cases `fromInts` should be
 -- | used.
-unsafeFromInts ∷ Int → Int → Int → Int → IPv4Address
+unsafeFromInts :: Int -> Int -> Int -> Int -> IPv4Address
 unsafeFromInts o1 o2 o3 o4 =
   case fromInts o1 o2 o3 o4 of
-    Just addr → addr
-    Nothing → unsafeCrashWith "IPv4Address octet was out of range"
+    Just addr -> addr
+    Nothing -> unsafeCrashWith "IPv4Address octet was out of range"
 
 -- | A parser for IPv4 addresses.
-parser ∷ Parser String IPv4Address
+parser :: Parser String IPv4Address
 parser = do
-  o1 ← octet <* char '.'
-  o2 ← octet <* char '.'
-  o3 ← octet <* char '.'
-  o4 ← octet
+  o1 <- octet <* char '.'
+  o2 <- octet <* char '.'
+  o3 <- octet <* char '.'
+  o4 <- octet
   pure $ IPv4Address o1 o2 o3 o4
 
 -- | A printer for IPv4 adddresses.
-print ∷ IPv4Address → String
+print :: IPv4Address -> String
 print (IPv4Address o1 o2 o3 o4) =
   show o1 <> "." <> show o2 <> "." <> show o3 <> "." <> show o4
 
-octet ∷ Parser String Int
+octet :: Parser String Int
 octet = wrapParser toInt
-  $ try ((\x y z → String.fromCharArray [x, y, z]) <$> nzDigit <*> digit <*> digit)
-  <|> try ((\x y → String.fromCharArray [x, y]) <$> nzDigit <*> digit)
-  <|> (String.singleton <$> digit)
+  $ try ((\x y z -> String.fromCharArray [ x, y, z ]) <$> nzDigit <*> digit <*> digit)
+      <|> try ((\x y -> String.fromCharArray [ x, y ]) <$> nzDigit <*> digit)
+      <|> (String.singleton <$> digit)
 
-nzDigit ∷ Parser String Char
-nzDigit = satisfy (\c → c >= '1' && c <= '9')
+nzDigit :: Parser String Char
+nzDigit = satisfy (\c -> c >= '1' && c <= '9')
 
-toInt ∷ String → Either URIPartParseError Int
+toInt :: String -> Either URIPartParseError Int
 toInt s = case Int.fromString s of
-  Just n | n >= 0 && n <= 255 → Right n
-  _ → Left (URIPartParseError "Invalid IPv4 address octet")
+  Just n | n >= 0 && n <= 255 -> Right n
+  _ -> Left (URIPartParseError "Invalid IPv4 address octet")

--- a/src/URI/Host/IPv6Address.purs
+++ b/src/URI/Host/IPv6Address.purs
@@ -20,23 +20,23 @@ import Text.Parsing.Parser.Token (hexDigit)
 -- | anything through that looks vaguely IPv6ish.
 newtype IPv6Address = IPv6Address String
 
-derive newtype instance eqIPv6Address ∷ Eq IPv6Address
-derive newtype instance ordIPv6Address ∷ Ord IPv6Address
+derive newtype instance eqIPv6Address :: Eq IPv6Address
+derive newtype instance ordIPv6Address :: Ord IPv6Address
 
-instance showIPv6Address ∷ Show IPv6Address where
+instance showIPv6Address :: Show IPv6Address where
   show (IPv6Address s) = "(IPv6Address.unsafeFromString " <> show s <> ")"
 
-unsafeFromString ∷ String → IPv6Address
+unsafeFromString :: String -> IPv6Address
 unsafeFromString = IPv6Address
 
-unsafeToString ∷ IPv6Address → String
+unsafeToString :: IPv6Address -> String
 unsafeToString (IPv6Address s) = "[" <> s <> "]"
 
-parser ∷ Parser String IPv6Address
+parser :: Parser String IPv6Address
 parser =
   IPv6Address
     <$> (char '[' *> (NES.joinWith "" <$> List.someRec (NESCU.singleton <$> ipv6Char)) <* char ']')
     <?> "IPv6 address"
   where
-    ipv6Char ∷ Parser String Char
-    ipv6Char = hexDigit <|> char ':' <|> char '.'
+  ipv6Char :: Parser String Char
+  ipv6Char = hexDigit <|> char ':' <|> char '.'

--- a/src/URI/Host/RegName.purs
+++ b/src/URI/Host/RegName.purs
@@ -24,11 +24,11 @@ import URI.Common (decodeURIComponent', subDelims, unreserved, pctEncoded, print
 -- | actually a name, rather than an IP address).
 newtype RegName = RegName NonEmptyString
 
-derive newtype instance eqRegName ∷ Eq RegName
-derive newtype instance ordRegName ∷ Ord RegName
-derive newtype instance semigroupRegName ∷ Semigroup RegName
+derive newtype instance eqRegName :: Eq RegName
+derive newtype instance ordRegName :: Ord RegName
+derive newtype instance semigroupRegName :: Semigroup RegName
 
-instance showRegName ∷ Show RegName where
+instance showRegName :: Show RegName where
   show (RegName s) = "(RegName.unsafeFromString " <> show s <> ")"
 
 -- | Constructs a reg-name value from a string, percent-encoding any characters
@@ -41,7 +41,7 @@ instance showRegName ∷ Show RegName where
 -- | fromString "foo:bar" = unsafeFromString "foo%3Abar"
 -- | fromString "foo%3Abar" = unsafeFromString "foo%253Abar"
 -- | ```
-fromString ∷ NonEmptyString → RegName
+fromString :: NonEmptyString -> RegName
 fromString = RegName <<< printEncoded' regNameChar
 
 -- | Returns the string value for a reg-name, percent-decoding any characters
@@ -51,32 +51,32 @@ fromString = RegName <<< printEncoded' regNameChar
 -- | toString (unsafeFromString "foo.com") = "foo.com"
 -- | toString (unsafeFromString "foo%3Abar") = "foo:bar"
 -- | ```
-toString ∷ RegName → NonEmptyString
+toString :: RegName -> NonEmptyString
 toString (RegName s) = decodeURIComponent' s
 
 -- | Constructs a query value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the query, to prevent double-encoding.
-unsafeFromString ∷ NonEmptyString → RegName
+unsafeFromString :: NonEmptyString -> RegName
 unsafeFromString = RegName
 
 -- | Returns the string value for the reg-name without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeToString ∷ RegName → NonEmptyString
+unsafeToString :: RegName -> NonEmptyString
 unsafeToString (RegName s) = s
 
 -- | A parser for reg-names.
-parser ∷ Parser String RegName
+parser :: Parser String RegName
 parser = RegName <<< NES.join1With "" <$> NEA.some p
   where
   p = pctEncoded <|> NES.singleton <$> regNameChar
 
 -- | A printer for reg-names.
-print ∷ RegName → String
+print :: RegName -> String
 print = NES.toString <<< unsafeToString
 
 -- | The supported reg-name characters, excluding percent-encodings.
-regNameChar ∷ Parser String Char
+regNameChar :: Parser String Char
 regNameChar = unreserved <|> subDelims

--- a/src/URI/HostPortPair.purs
+++ b/src/URI/HostPortPair.purs
@@ -31,18 +31,18 @@ type HostPortPair host port = Maybe (These host port)
 -- | [`URI.Extra.MultiHostPortPair`](../URI.Extra.MultiHostPortPair) for an
 -- | example of this.
 parser
-  ∷ ∀ host port
-  . (Host → Either URIPartParseError host)
-  → (Port → Either URIPartParseError port)
-  → Parser String (HostPortPair host port)
+  :: forall host port
+   . (Host -> Either URIPartParseError host)
+  -> (Port -> Either URIPartParseError port)
+  -> Parser String (HostPortPair host port)
 parser parseHost parsePort = do
-  mh ← optionMaybe (wrapParser parseHost Host.parser)
-  mp ← optionMaybe (wrapParser parsePort Port.parser)
+  mh <- optionMaybe (wrapParser parseHost Host.parser)
+  mp <- optionMaybe (wrapParser parsePort Port.parser)
   pure case mh, mp of
-    Just h, Nothing → Just (This h)
-    Nothing, Just p → Just (That p)
-    Just h, Just p → Just (Both h p)
-    Nothing, Nothing → Nothing
+    Just h, Nothing -> Just (This h)
+    Nothing, Just p -> Just (That p)
+    Just h, Just p -> Just (Both h p)
+    Nothing, Nothing -> Nothing
 
 -- | A printer for a spec-conformant host/port pair.
 -- |
@@ -50,17 +50,17 @@ parser parseHost parsePort = do
 -- | and `Port` components to be printed back from their custom representations.
 -- | If no custom types are being used, pass `identity` for both of these arguments.
 print
-  ∷ ∀ host port
-  . (host → Host)
-  → (port → Port)
-  → HostPortPair host port
-  → String
+  :: forall host port
+   . (host -> Host)
+  -> (port -> Port)
+  -> HostPortPair host port
+  -> String
 print printHost printPort = case _ of
-  Nothing →
+  Nothing ->
     ""
-  Just (This host) →
+  Just (This host) ->
     Host.print (printHost host)
-  Just (That port) →
+  Just (That port) ->
     Port.print (printPort port)
-  Just (Both host port) →
+  Just (Both host port) ->
     Host.print (printHost host) <> Port.print (printPort port)

--- a/src/URI/HostPortPair/Gen.purs
+++ b/src/URI/HostPortPair/Gen.purs
@@ -15,21 +15,21 @@ import URI.Port.Gen (genPort)
 
 -- | Generates a random `HostPortPair` for testing purposes.
 genHostPortPair
-  ∷ ∀ m host port
-  . Gen.MonadGen m
-  ⇒ m host
-  → m port
-  → m (HostPortPair host port)
+  :: forall m host port
+   . Gen.MonadGen m
+  => m host
+  -> m port
+  -> m (HostPortPair host port)
 genHostPortPair host port = do
-  h ← sometimes 0.75 host
-  p ← sometimes 0.25 port
+  h <- sometimes 0.75 host
+  p <- sometimes 0.25 port
   pure case h, p of
-    Just h', Just p' → Just (Both h' p')
-    Just h', Nothing → Just (This h')
-    Nothing, Just p' → Just (That p')
-    Nothing, Nothing → Nothing
+    Just h', Just p' -> Just (Both h' p')
+    Just h', Nothing -> Just (This h')
+    Nothing, Just p' -> Just (That p')
+    Nothing, Nothing -> Nothing
   where
-  sometimes ∷ ∀ a. Number → m a → m (Maybe a)
+  sometimes :: forall a. Number -> m a -> m (Maybe a)
   sometimes chance g = do
-    n ← Gen.chooseFloat 0.0 1.0
+    n <- Gen.chooseFloat 0.0 1.0
     if n > chance then Just <$> g else pure Nothing

--- a/src/URI/Path.purs
+++ b/src/URI/Path.purs
@@ -23,6 +23,7 @@ derive newtype instance ordPath :: Ord Path
 derive newtype instance semigroupPath :: Semigroup Path
 derive newtype instance monoidPath :: Monoid Path
 derive instance genericPath :: Generic Path _
+
 instance showPath :: Show Path where
   show = genericShow
 

--- a/src/URI/Path.purs
+++ b/src/URI/Path.purs
@@ -18,19 +18,20 @@ import URI.Path.Segment (PathSegment, parseSegment, unsafeSegmentToString)
 -- | A path value of `/` corresponds to `Path [""]`, an empty path is `Path []`.
 newtype Path = Path (Array PathSegment)
 
-derive newtype instance eqPath ∷ Eq Path
-derive newtype instance ordPath ∷ Ord Path
-derive newtype instance semigroupPath ∷ Semigroup Path
-derive newtype instance monoidPath ∷ Monoid Path
-derive instance genericPath ∷ Generic Path _
-instance showPath ∷ Show Path where show = genericShow
+derive newtype instance eqPath :: Eq Path
+derive newtype instance ordPath :: Ord Path
+derive newtype instance semigroupPath :: Semigroup Path
+derive newtype instance monoidPath :: Monoid Path
+derive instance genericPath :: Generic Path _
+instance showPath :: Show Path where
+  show = genericShow
 
 -- | A parser for a _path-abempty_ URI component.
-parser ∷ Parser String Path
+parser :: Parser String Path
 parser = Path <<< Array.fromFoldable <$> List.manyRec (char '/' *> parseSegment)
 
 -- | A printer for a _path-abempty_ URI component.
-print ∷ Path → String
+print :: Path -> String
 print (Path segs)
   | Array.null segs = ""
   | otherwise = "/" <> String.joinWith "/" (map unsafeSegmentToString segs)

--- a/src/URI/Path/Absolute.purs
+++ b/src/URI/Path/Absolute.purs
@@ -29,6 +29,7 @@ newtype PathAbsolute = PathAbsolute (Maybe (Tuple PathSegmentNZ (Array PathSegme
 derive instance eqPathAbsolute :: Eq PathAbsolute
 derive instance ordPathAbsolute :: Ord PathAbsolute
 derive instance genericPathAbsolute :: Generic PathAbsolute _
+
 instance showPathAbsolute :: Show PathAbsolute where
   show = genericShow
 

--- a/src/URI/Path/Absolute.purs
+++ b/src/URI/Path/Absolute.purs
@@ -26,33 +26,34 @@ import URI.Path.Segment (PathSegment, PathSegmentNZ, parseSegment, parseSegmentN
 -- | path means the same thing as `/` anyway!
 newtype PathAbsolute = PathAbsolute (Maybe (Tuple PathSegmentNZ (Array PathSegment)))
 
-derive instance eqPathAbsolute ∷ Eq PathAbsolute
-derive instance ordPathAbsolute ∷ Ord PathAbsolute
-derive instance genericPathAbsolute ∷ Generic PathAbsolute _
-instance showPathAbsolute ∷ Show PathAbsolute where show = genericShow
+derive instance eqPathAbsolute :: Eq PathAbsolute
+derive instance ordPathAbsolute :: Ord PathAbsolute
+derive instance genericPathAbsolute :: Generic PathAbsolute _
+instance showPathAbsolute :: Show PathAbsolute where
+  show = genericShow
 
 -- | A parser for a _path-absolute_ URI component.
-parse ∷ Parser String PathAbsolute
+parse :: Parser String PathAbsolute
 parse = do
-  _ ← char '/'
+  _ <- char '/'
   optionMaybe parseSegmentNZ >>= case _ of
-    Just head →
+    Just head ->
       PathAbsolute
         <<< Just
         <<< Tuple head
         <<< Array.fromFoldable
         <$> List.manyRec (char '/' *> parseSegment)
-    Nothing →
+    Nothing ->
       pure (PathAbsolute Nothing)
 
 -- | A printer for a _path-absolute_ URI component.
-print ∷ PathAbsolute → String
+print :: PathAbsolute -> String
 print = case _ of
-  PathAbsolute Nothing →
+  PathAbsolute Nothing ->
     "/"
-  PathAbsolute (Just (Tuple head [])) →
+  PathAbsolute (Just (Tuple head [])) ->
     "/" <> printSegmentNZ head
-  PathAbsolute (Just (Tuple head tail)) →
+  PathAbsolute (Just (Tuple head tail)) ->
     "/"
       <> printSegmentNZ head
       <> "/"

--- a/src/URI/Path/NoScheme.purs
+++ b/src/URI/Path/NoScheme.purs
@@ -19,21 +19,22 @@ import URI.Path.Segment (PathSegment, PathSegmentNZNC, parseSegment, parseSegmen
 -- | component.
 newtype PathNoScheme = PathNoScheme (Tuple PathSegmentNZNC (Array PathSegment))
 
-derive instance eqPathNoScheme ∷ Eq PathNoScheme
-derive instance ordPathNoScheme ∷ Ord PathNoScheme
-derive instance genericPathNoScheme ∷ Generic PathNoScheme _
-instance showPathNoScheme ∷ Show PathNoScheme where show = genericShow
+derive instance eqPathNoScheme :: Eq PathNoScheme
+derive instance ordPathNoScheme :: Ord PathNoScheme
+derive instance genericPathNoScheme :: Generic PathNoScheme _
+instance showPathNoScheme :: Show PathNoScheme where
+  show = genericShow
 
 -- | A parser for a _path-noscheme_ URI component.
-parse ∷ Parser String PathNoScheme
+parse :: Parser String PathNoScheme
 parse = do
-  head ← parseSegmentNZNC
-  tail ← List.manyRec (char '/' *> parseSegment)
+  head <- parseSegmentNZNC
+  tail <- List.manyRec (char '/' *> parseSegment)
   pure (PathNoScheme (Tuple head (Array.fromFoldable tail)))
 
 -- | A printer for a _path-noscheme_ URI component.
-print ∷ PathNoScheme → String
+print :: PathNoScheme -> String
 print (PathNoScheme (Tuple head tail)) =
   case tail of
-    [] → printSegmentNZNC head
-    _ → printSegmentNZNC head <> "/" <> String.joinWith "/" (map printSegment tail)
+    [] -> printSegmentNZNC head
+    _ -> printSegmentNZNC head <> "/" <> String.joinWith "/" (map printSegment tail)

--- a/src/URI/Path/NoScheme.purs
+++ b/src/URI/Path/NoScheme.purs
@@ -22,6 +22,7 @@ newtype PathNoScheme = PathNoScheme (Tuple PathSegmentNZNC (Array PathSegment))
 derive instance eqPathNoScheme :: Eq PathNoScheme
 derive instance ordPathNoScheme :: Ord PathNoScheme
 derive instance genericPathNoScheme :: Generic PathNoScheme _
+
 instance showPathNoScheme :: Show PathNoScheme where
   show = genericShow
 

--- a/src/URI/Path/Rootless.purs
+++ b/src/URI/Path/Rootless.purs
@@ -17,24 +17,25 @@ import URI.Path.Segment (PathSegment, PathSegmentNZ, parseSegment, parseSegmentN
 -- | appear in a hierarchical-part when there is no authority component.
 newtype PathRootless = PathRootless (Tuple PathSegmentNZ (Array PathSegment))
 
-derive instance eqPathRootless ∷ Eq PathRootless
-derive instance ordPathRootless ∷ Ord PathRootless
-derive instance genericPathRootless ∷ Generic PathRootless _
-instance showPathRootless ∷ Show PathRootless where show = genericShow
+derive instance eqPathRootless :: Eq PathRootless
+derive instance ordPathRootless :: Ord PathRootless
+derive instance genericPathRootless :: Generic PathRootless _
+instance showPathRootless :: Show PathRootless where
+  show = genericShow
 
 -- | A parser for a _path-rootless_ URI component.
-parse ∷ Parser String PathRootless
+parse :: Parser String PathRootless
 parse = do
-  head ← parseSegmentNZ
-  tail ← List.manyRec (char '/' *> parseSegment)
+  head <- parseSegmentNZ
+  tail <- List.manyRec (char '/' *> parseSegment)
   pure (PathRootless (Tuple head (Array.fromFoldable tail)))
 
 -- | A printer for a _path-rootless_ URI component.
-print ∷ PathRootless → String
+print :: PathRootless -> String
 print = case _ of
-  PathRootless (Tuple head []) →
+  PathRootless (Tuple head []) ->
     printSegmentNZ head
-  PathRootless (Tuple head tail) →
+  PathRootless (Tuple head tail) ->
     printSegmentNZ head
       <> "/"
       <> String.joinWith "/" (map printSegment tail)

--- a/src/URI/Path/Rootless.purs
+++ b/src/URI/Path/Rootless.purs
@@ -20,6 +20,7 @@ newtype PathRootless = PathRootless (Tuple PathSegmentNZ (Array PathSegment))
 derive instance eqPathRootless :: Eq PathRootless
 derive instance ordPathRootless :: Ord PathRootless
 derive instance genericPathRootless :: Generic PathRootless _
+
 instance showPathRootless :: Show PathRootless where
   show = genericShow
 

--- a/src/URI/Path/Segment.purs
+++ b/src/URI/Path/Segment.purs
@@ -45,145 +45,145 @@ import URI.Common (decodeURIComponent', pctEncoded, printEncoded, printEncoded',
 -- | empty path segments. Corresponds to _segment_ in the spec.
 newtype PathSegment = PathSegment String
 
-derive newtype instance eqPathSegment ∷ Eq PathSegment
-derive newtype instance ordPathSegment ∷ Ord PathSegment
+derive newtype instance eqPathSegment :: Eq PathSegment
+derive newtype instance ordPathSegment :: Ord PathSegment
 
-instance showPathSegment ∷ Show PathSegment where
+instance showPathSegment :: Show PathSegment where
   show (PathSegment s) = "(Segment.unsafeSegmentToString " <> show s <> ")"
 
 -- | Constructs a segment value from a string, percent-encoding any characters
 -- | that require it. Note that running this on a string that has already had
 -- | percent-encoding applied will double-encode it, for those situations use
 -- | `unsafeSegmentFromString` instead.
-segmentFromString ∷ String → PathSegment
+segmentFromString :: String -> PathSegment
 segmentFromString = PathSegment <<< printEncoded segmentChar
 
 -- | Returns the string value for a segment, percent-decoding any characters
 -- | that require it.
-segmentToString ∷ PathSegment → String
+segmentToString :: PathSegment -> String
 segmentToString (PathSegment s) = unsafePartial $ fromJust $ decodeURIComponent s
 
 -- | Constructs a segment value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the segment, to prevent double-encoding.
-unsafeSegmentFromString ∷ String → PathSegment
+unsafeSegmentFromString :: String -> PathSegment
 unsafeSegmentFromString = PathSegment
 
 -- | Returns the string value for the segment without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `segmentFromString`/
 -- | `unsafeSegmentFromString` pairing.
-unsafeSegmentToString ∷ PathSegment → String
+unsafeSegmentToString :: PathSegment -> String
 unsafeSegmentToString (PathSegment s) = s
 
 -- | A parser for a _segment_ component of a URI.
-parseSegment ∷ Parser String PathSegment
+parseSegment :: Parser String PathSegment
 parseSegment =
   PathSegment
     <<< NES.joinWith ""
     <$> List.manyRec (pctEncoded <|> NES.singleton <$> segmentChar)
 
 -- | A printer for a _segment_ component of a URI.
-printSegment ∷ PathSegment → String
+printSegment :: PathSegment -> String
 printSegment = unsafeSegmentToString
 
 -- | A path segment that cannot be empty. Corresponds to _segment-nz_ in the
 -- | spec.
 newtype PathSegmentNZ = PathSegmentNZ NonEmptyString
 
-derive newtype instance eqPathSegmentNZ ∷ Eq PathSegmentNZ
-derive newtype instance ordPathSegmentNZ ∷ Ord PathSegmentNZ
+derive newtype instance eqPathSegmentNZ :: Eq PathSegmentNZ
+derive newtype instance ordPathSegmentNZ :: Ord PathSegmentNZ
 
-instance showPathSegmentNZ ∷ Show PathSegmentNZ where
+instance showPathSegmentNZ :: Show PathSegmentNZ where
   show (PathSegmentNZ s) = "(Segment.unsafeSegmentNZFromString " <> show s <> ")"
 
 -- | Constructs a non-empty segment value from a string, percent-encoding any
 -- | characters that require it. Note that running this on a string that has
 -- | already had percent-encoding applied will double-encode it, for those
 -- | situations use `unsafeSegmentNZFromString` instead.
-segmentNZFromString ∷ NonEmptyString → PathSegmentNZ
+segmentNZFromString :: NonEmptyString -> PathSegmentNZ
 segmentNZFromString = PathSegmentNZ <<< printEncoded' segmentChar
 
 -- | Returns the string value for a non-empty segment, percent-decoding any
 -- | characters that require it.
-segmentNZToString ∷ PathSegmentNZ → NonEmptyString
+segmentNZToString :: PathSegmentNZ -> NonEmptyString
 segmentNZToString (PathSegmentNZ s) = decodeURIComponent' s
 
 -- | Constructs a non-empty segment value from a string directly - no
 -- | percent-encoding will be applied. This is useful when using a custom
 -- | encoding scheme for the segment, to prevent double-encoding.
-unsafeSegmentNZFromString ∷ NonEmptyString → PathSegmentNZ
+unsafeSegmentNZFromString :: NonEmptyString -> PathSegmentNZ
 unsafeSegmentNZFromString = PathSegmentNZ
 
 -- | Returns the string value for a non-empty segment without percent-decoding.
 -- | Only "unsafe" in the sense that values this produces may need further
 -- | decoding, the name is more for symmetry with the `segmentNZFromString`/
 -- | `unsafeSegmentNZFromString` pairing.
-unsafeSegmentNZToString ∷ PathSegmentNZ → NonEmptyString
+unsafeSegmentNZToString :: PathSegmentNZ -> NonEmptyString
 unsafeSegmentNZToString (PathSegmentNZ s) = s
 
 -- | A parser for a _segment-nz_ component of a URI.
-parseSegmentNZ ∷ Parser String PathSegmentNZ
+parseSegmentNZ :: Parser String PathSegmentNZ
 parseSegmentNZ =
   PathSegmentNZ
     <<< NES.join1With ""
     <$> NEA.some (pctEncoded <|> NES.singleton <$> segmentChar)
 
 -- | A printer for a _segment-nz_ component of a URI.
-printSegmentNZ ∷ PathSegmentNZ → String
+printSegmentNZ :: PathSegmentNZ -> String
 printSegmentNZ = NES.toString <<< unsafeSegmentNZToString
 
 -- | A path segment that cannot be empty or contain the `:` character.
 -- | Corresponds to _segment-nz-nc_ in the spec.
 newtype PathSegmentNZNC = PathSegmentNZNC NonEmptyString
 
-derive newtype instance eqPathSegmentNZNC ∷ Eq PathSegmentNZNC
-derive newtype instance ordPathSegmentNZNC ∷ Ord PathSegmentNZNC
+derive newtype instance eqPathSegmentNZNC :: Eq PathSegmentNZNC
+derive newtype instance ordPathSegmentNZNC :: Ord PathSegmentNZNC
 
-instance showPathSegmentNZNC ∷ Show PathSegmentNZNC where
+instance showPathSegmentNZNC :: Show PathSegmentNZNC where
   show (PathSegmentNZNC s) = "(Segment.unsafeSegmentNZNCToString " <> show s <> ")"
 
 -- | Constructs a non-empty-no-colon segment value from a string,
 -- | percent-encoding any characters that require it. Note that running this on
 -- | a string that has already had percent-encoding applied will double-encode
 -- | it, for those situations use `unsafeSegmentNZNCFromString` instead.
-segmentNZNCFromString ∷ NonEmptyString → PathSegmentNZNC
+segmentNZNCFromString :: NonEmptyString -> PathSegmentNZNC
 segmentNZNCFromString = PathSegmentNZNC <<< printEncoded' segmentNCChar
 
 -- | Constructs a non-empty-no-colon segment value from a string directly - no
 -- | percent-encoding will be applied. This is useful when using a custom
 -- | encoding scheme for the segment, to prevent double-encoding.
-segmentNZNCToString ∷ PathSegmentNZNC → NonEmptyString
+segmentNZNCToString :: PathSegmentNZNC -> NonEmptyString
 segmentNZNCToString (PathSegmentNZNC s) = decodeURIComponent' s
 
 -- | Returns the string value for a non-empty-no-colon segment, percent-decoding
 -- | any characters that require it.
-unsafeSegmentNZNCFromString ∷ NonEmptyString → PathSegmentNZNC
+unsafeSegmentNZNCFromString :: NonEmptyString -> PathSegmentNZNC
 unsafeSegmentNZNCFromString = PathSegmentNZNC
 
 -- | Returns the string value for the non-empty-no-colon segment without
 -- | percent-decoding. Only "unsafe" in the sense that values this produces may
 -- | need further decoding, the name is more for symmetry with the
 -- | `segmentNZNCFromString`/`unsafeSegmentNZNCFromString` pairing.
-unsafeSegmentNZNCToString ∷ PathSegmentNZNC → NonEmptyString
+unsafeSegmentNZNCToString :: PathSegmentNZNC -> NonEmptyString
 unsafeSegmentNZNCToString (PathSegmentNZNC s) = s
 
 -- | A parser for a _segment-nz-nc_ component of a URI.
-parseSegmentNZNC ∷ Parser String PathSegmentNZNC
+parseSegmentNZNC :: Parser String PathSegmentNZNC
 parseSegmentNZNC =
   PathSegmentNZNC
     <<< NES.join1With ""
     <$> NEA.some (pctEncoded <|> NES.singleton <$> segmentNCChar)
 
 -- | A printer for a _segment-nz-nc_ component of a URI.
-printSegmentNZNC ∷ PathSegmentNZNC → String
+printSegmentNZNC :: PathSegmentNZNC -> String
 printSegmentNZNC = NES.toString <<< unsafeSegmentNZNCToString
 
 -- | The supported path segment characters, excluding percent-encodings.
-segmentChar ∷ Parser String Char
+segmentChar :: Parser String Char
 segmentChar = segmentNCChar <|> char ':'
 
 -- | The supported no-colon path segment characters, excluding
 -- | percent-encodings.
-segmentNCChar ∷ Parser String Char
+segmentNCChar :: Parser String Char
 segmentNCChar = unreserved <|> subDelims <|> char '@'

--- a/src/URI/Port.purs
+++ b/src/URI/Port.purs
@@ -22,19 +22,19 @@ import Text.Parsing.Parser.Token (digit)
 -- | The port component of a host in a URI.
 newtype Port = Port Int
 
-derive newtype instance eqPort ∷ Eq Port
-derive newtype instance ordPort ∷ Ord Port
+derive newtype instance eqPort :: Eq Port
+derive newtype instance ordPort :: Ord Port
 
-instance showPort ∷ Show Port where
+instance showPort :: Show Port where
   show (Port i) = "(Port.unsafeFromInt " <> show i <> ")"
 
 -- | Returns the port number as an integer.
-toInt ∷ Port → Int
+toInt :: Port -> Int
 toInt (Port i) = i
 
 -- | Attempts to create a port from the passed integer. If the value falls
 -- | outside of the range 0-65535 (inclusive) `Nothing` will be returned.
-fromInt ∷ Int → Maybe Port
+fromInt :: Int -> Maybe Port
 fromInt i
   | i >= 0 && i <= 65535 = Just (Port i)
   | otherwise = Nothing
@@ -44,22 +44,22 @@ fromInt i
 -- |
 -- | This is intended as a convenience when describing `Port`s statically in
 -- | PureScript code, in all other cases `fromInt` should be preferred.
-unsafeFromInt ∷ Int → Port
+unsafeFromInt :: Int -> Port
 unsafeFromInt i =
   case fromInt i of
-    Just addr → addr
-    Nothing → unsafeCrashWith $ "Port value " <> show i <> " is out of range"
+    Just addr -> addr
+    Nothing -> unsafeCrashWith $ "Port value " <> show i <> " is out of range"
 
 -- | A parser for the port component of a host in a URI. Expects values with a
 -- | `':'` prefix.
-parser ∷ Parser String Port
+parser :: Parser String Port
 parser = do
-  s ← NES.joinWith "" <$> (char ':' *> List.someRec (NES.singleton <$> digit))
+  s <- NES.joinWith "" <$> (char ':' *> List.someRec (NES.singleton <$> digit))
   case fromStringAs decimal s of
-    Just x → pure (Port x)
-    _ → fail "Expected a valid port number"
+    Just x -> pure (Port x)
+    _ -> fail "Expected a valid port number"
 
 -- | A printer for the port component of a host in a URI. Will print the value
 -- | with a `':'` prefix.
-print ∷ Port → String
+print :: Port -> String
 print (Port x) = ":" <> show x

--- a/src/URI/Port/Gen.purs
+++ b/src/URI/Port/Gen.purs
@@ -7,5 +7,5 @@ import URI.Port (Port)
 import URI.Port as Port
 
 -- | Generates a random `Port` for testing purposes.
-genPort ∷ ∀ m. Gen.MonadGen m ⇒ m Port
+genPort :: forall m. Gen.MonadGen m => m Port
 genPort = Port.unsafeFromInt <$> Gen.chooseInt 0 65535

--- a/src/URI/Query.purs
+++ b/src/URI/Query.purs
@@ -29,12 +29,12 @@ import URI.Common (subDelims, unreserved, pctEncoded, printEncoded)
 -- | a look at `URI.Extra.QueryPairs`.
 newtype Query = Query String
 
-derive newtype instance eqQuery ∷ Eq Query
-derive newtype instance ordQuery ∷ Ord Query
-derive newtype instance semigroupQuery ∷ Semigroup Query
-derive newtype instance monoidQuery ∷ Monoid Query
+derive newtype instance eqQuery :: Eq Query
+derive newtype instance ordQuery :: Ord Query
+derive newtype instance semigroupQuery :: Semigroup Query
+derive newtype instance monoidQuery :: Monoid Query
 
-instance showQuery ∷ Show Query where
+instance showQuery :: Show Query where
   show (Query s) = "(Query.unsafeFromString " <> show s <> ")"
 
 -- | Constructs a query value from a string, percent-encoding any characters
@@ -47,7 +47,7 @@ instance showQuery ∷ Show Query where
 -- | fromString "foo#bar" = unsafeFromString "foo%23bar"
 -- | fromString "foo%23bar" = unsafeFromString "foo%2523bar"
 -- | ```
-fromString ∷ String → Query
+fromString :: String -> Query
 fromString = Query <<< printEncoded queryChar
 
 -- | Returns the string value for a query, percent-decoding any characters
@@ -57,39 +57,39 @@ fromString = Query <<< printEncoded queryChar
 -- | toString (unsafeFromString "foo") = "foo"
 -- | toString (unsafeFromString "foo%23bar") = "foo#bar"
 -- | ```
-toString ∷ Query → String
+toString :: Query -> String
 toString (Query s) = unsafePartial $ fromJust $ decodeURIComponent s
 
 -- | Constructs a query value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the query, to prevent double-encoding.
-unsafeFromString ∷ String → Query
+unsafeFromString :: String -> Query
 unsafeFromString = Query
 
 -- | Returns the string value for a query without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeToString ∷ Query → String
+unsafeToString :: Query -> String
 unsafeToString (Query s) = s
 
 -- | A parser for the query component of a URI. Expects values with a `'?'`
 -- | prefix.
-parser ∷ Parser String Query
+parser :: Parser String Query
 parser =
   char '?' *>
-    (Query <<< NES.joinWith ""
-      <$> List.manyRec (NES.singleton <$> queryChar <|> pctEncoded))
+    ( Query <<< NES.joinWith ""
+        <$> List.manyRec (NES.singleton <$> queryChar <|> pctEncoded)
+    )
 
 -- | A printer for the query component of a URI. Will print the value with
 -- | a `'?'` prefix.
-print ∷ Query → String
+print :: Query -> String
 print (Query s) = "?" <> s
 
 -- | The supported query characters, excluding percent-encodings.
-queryChar ∷ Parser String Char
-queryChar
-  = unreserved
+queryChar :: Parser String Char
+queryChar = unreserved
   <|> subDelims
   <|> char ':'
   <|> char '@'

--- a/src/URI/RelativeRef.purs
+++ b/src/URI/RelativeRef.purs
@@ -39,6 +39,7 @@ data RelativeRef userInfo hosts path relPath query fragment = RelativeRef (Relat
 derive instance eqRelativeRef :: (Eq userInfo, Eq hosts, Eq path, Eq relPath, Eq query, Eq fragment) => Eq (RelativeRef userInfo hosts path relPath query fragment)
 derive instance ordRelativeRef :: (Ord userInfo, Ord hosts, Ord path, Ord relPath, Ord query, Ord fragment) => Ord (RelativeRef userInfo hosts path relPath query fragment)
 derive instance genericRelativeRef :: Generic (RelativeRef userInfo hosts path relPath query fragment) _
+
 instance showRelativeRef :: (Show userInfo, Show hosts, Show path, Show relPath, Show query, Show fragment) => Show (RelativeRef userInfo hosts path relPath query fragment) where
   show = genericShow
 
@@ -118,33 +119,21 @@ print opts (RelativeRef h q f) =
     ]
 
 -- | The relative-part component of a relative URI.
-_relPart
-  :: forall userInfo hosts path relPath query fragment
-   . Lens'
-       (RelativeRef userInfo hosts path relPath query fragment)
-       (RelativePart userInfo hosts path relPath)
+_relPart :: forall userInfo hosts path relPath query fragment. Lens' (RelativeRef userInfo hosts path relPath query fragment) (RelativePart userInfo hosts path relPath)
 _relPart =
   lens
     (\(RelativeRef r _ _) -> r)
     (\(RelativeRef _ q f) r -> RelativeRef r q f)
 
 -- | The query component of a relative URI.
-_query
-  :: forall userInfo hosts path relPath query fragment
-   . Lens'
-       (RelativeRef userInfo hosts path relPath query fragment)
-       (Maybe query)
+_query :: forall userInfo hosts path relPath query fragment. Lens' (RelativeRef userInfo hosts path relPath query fragment) (Maybe query)
 _query =
   lens
     (\(RelativeRef _ q _) -> q)
     (\(RelativeRef r _ f) q -> RelativeRef r q f)
 
 -- | The fragment component of a relative URI.
-_fragment
-  :: forall userInfo hosts path relPath query fragment
-   . Lens'
-       (RelativeRef userInfo hosts path relPath query fragment)
-       (Maybe fragment)
+_fragment :: forall userInfo hosts path relPath query fragment. Lens' (RelativeRef userInfo hosts path relPath query fragment) (Maybe fragment)
 _fragment =
   lens
     (\(RelativeRef _ _ f) -> f)

--- a/src/URI/RelativeRef.purs
+++ b/src/URI/RelativeRef.purs
@@ -36,10 +36,11 @@ import URI.RelativePart as RPart
 -- | A relative URI. Relative in the sense that it lacks a `Scheme` component.
 data RelativeRef userInfo hosts path relPath query fragment = RelativeRef (RelativePart userInfo hosts path relPath) (Maybe query) (Maybe fragment)
 
-derive instance eqRelativeRef ∷ (Eq userInfo, Eq hosts, Eq path, Eq relPath, Eq query, Eq fragment) ⇒ Eq (RelativeRef userInfo hosts path relPath query fragment)
-derive instance ordRelativeRef ∷ (Ord userInfo, Ord hosts, Ord path, Ord relPath, Ord query, Ord fragment) ⇒ Ord (RelativeRef userInfo hosts path relPath query fragment)
-derive instance genericRelativeRef ∷ Generic (RelativeRef userInfo hosts path relPath query fragment) _
-instance showRelativeRef ∷ (Show userInfo, Show hosts, Show path, Show relPath, Show query, Show fragment) ⇒ Show (RelativeRef userInfo hosts path relPath query fragment) where show = genericShow
+derive instance eqRelativeRef :: (Eq userInfo, Eq hosts, Eq path, Eq relPath, Eq query, Eq fragment) => Eq (RelativeRef userInfo hosts path relPath query fragment)
+derive instance ordRelativeRef :: (Ord userInfo, Ord hosts, Ord path, Ord relPath, Ord query, Ord fragment) => Ord (RelativeRef userInfo hosts path relPath query fragment)
+derive instance genericRelativeRef :: Generic (RelativeRef userInfo hosts path relPath query fragment) _
+instance showRelativeRef :: (Show userInfo, Show hosts, Show path, Show relPath, Show query, Show fragment) => Show (RelativeRef userInfo hosts path relPath query fragment) where
+  show = genericShow
 
 -- | A row type for describing the options fields used by the relative URI
 -- | parser and printer.
@@ -64,12 +65,12 @@ type RelativeRefOptions userInfo hosts path relPath query fragment =
 -- | `HostPortPair.parseHosts pure pure`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair parser.
 type RelativeRefParseOptions userInfo hosts path relPath query fragment r =
-  ( parseUserInfo ∷ UserInfo → Either URIPartParseError userInfo
-  , parseHosts ∷ Parser String hosts
-  , parsePath ∷ Path → Either URIPartParseError path
-  , parseRelPath ∷ Either PathAbsolute PathNoScheme → Either URIPartParseError relPath
-  , parseQuery ∷ Query → Either URIPartParseError query
-  , parseFragment ∷ Fragment → Either URIPartParseError fragment
+  ( parseUserInfo :: UserInfo -> Either URIPartParseError userInfo
+  , parseHosts :: Parser String hosts
+  , parsePath :: Path -> Either URIPartParseError path
+  , parseRelPath :: Either PathAbsolute PathNoScheme -> Either URIPartParseError relPath
+  , parseQuery :: Query -> Either URIPartParseError query
+  , parseFragment :: Fragment -> Either URIPartParseError fragment
   | r
   )
 
@@ -82,20 +83,20 @@ type RelativeRefParseOptions userInfo hosts path relPath query fragment r =
 -- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type RelativeRefPrintOptions userInfo hosts path relPath query fragment r =
-  ( printUserInfo ∷ userInfo → UserInfo
-  , printHosts ∷ hosts → String
-  , printPath ∷ path → Path
-  , printRelPath ∷ relPath → Either PathAbsolute PathNoScheme
-  , printQuery ∷ query → Query
-  , printFragment ∷ fragment → Fragment
+  ( printUserInfo :: userInfo -> UserInfo
+  , printHosts :: hosts -> String
+  , printPath :: path -> Path
+  , printRelPath :: relPath -> Either PathAbsolute PathNoScheme
+  , printQuery :: query -> Query
+  , printFragment :: fragment -> Fragment
   | r
   )
 
 -- | A parser for a relative URI.
 parser
-  ∷ ∀ userInfo hosts path relPath query fragment r
-  . Record (RelativeRefParseOptions userInfo hosts path relPath query fragment r)
-  → Parser String (RelativeRef userInfo hosts path relPath query fragment)
+  :: forall userInfo hosts path relPath query fragment r
+   . Record (RelativeRefParseOptions userInfo hosts path relPath query fragment r)
+  -> Parser String (RelativeRef userInfo hosts path relPath query fragment)
 parser opts =
   RelativeRef
     <$> RPart.parser opts
@@ -105,10 +106,10 @@ parser opts =
 
 -- | A printer for a relative URI.
 print
-  ∷ ∀ userInfo hosts path relPath query fragment r
-  . Record (RelativeRefPrintOptions userInfo hosts path relPath query fragment r)
-  → RelativeRef userInfo hosts path relPath query fragment
-  → String
+  :: forall userInfo hosts path relPath query fragment r
+   . Record (RelativeRefPrintOptions userInfo hosts path relPath query fragment r)
+  -> RelativeRef userInfo hosts path relPath query fragment
+  -> String
 print opts (RelativeRef h q f) =
   String.joinWith "" $ Array.catMaybes
     [ Just (RPart.print opts h)
@@ -118,33 +119,33 @@ print opts (RelativeRef h q f) =
 
 -- | The relative-part component of a relative URI.
 _relPart
-  ∷ ∀ userInfo hosts path relPath query fragment
-  . Lens'
-      (RelativeRef userInfo hosts path relPath query fragment)
-      (RelativePart userInfo hosts path relPath)
+  :: forall userInfo hosts path relPath query fragment
+   . Lens'
+       (RelativeRef userInfo hosts path relPath query fragment)
+       (RelativePart userInfo hosts path relPath)
 _relPart =
   lens
-    (\(RelativeRef r _ _) → r)
-    (\(RelativeRef _ q f) r → RelativeRef r q f)
+    (\(RelativeRef r _ _) -> r)
+    (\(RelativeRef _ q f) r -> RelativeRef r q f)
 
 -- | The query component of a relative URI.
 _query
-  ∷ ∀ userInfo hosts path relPath query fragment
-  . Lens'
-      (RelativeRef userInfo hosts path relPath query fragment)
-      (Maybe query)
+  :: forall userInfo hosts path relPath query fragment
+   . Lens'
+       (RelativeRef userInfo hosts path relPath query fragment)
+       (Maybe query)
 _query =
   lens
-    (\(RelativeRef _ q _) → q)
-    (\(RelativeRef r _ f) q → RelativeRef r q f)
+    (\(RelativeRef _ q _) -> q)
+    (\(RelativeRef r _ f) q -> RelativeRef r q f)
 
 -- | The fragment component of a relative URI.
 _fragment
-  ∷ ∀ userInfo hosts path relPath query fragment
-  . Lens'
-      (RelativeRef userInfo hosts path relPath query fragment)
-      (Maybe fragment)
+  :: forall userInfo hosts path relPath query fragment
+   . Lens'
+       (RelativeRef userInfo hosts path relPath query fragment)
+       (Maybe fragment)
 _fragment =
   lens
-    (\(RelativeRef _ _ f) → f)
-    (\(RelativeRef r q _) f → RelativeRef r q f)
+    (\(RelativeRef _ _ f) -> f)
+    (\(RelativeRef r q _) f -> RelativeRef r q f)

--- a/src/URI/Scheme.purs
+++ b/src/URI/Scheme.purs
@@ -24,10 +24,10 @@ import URI.Common (alpha, alphaNum)
 -- | The scheme part of an absolute URI. For example: `http`, `ftp`, `git`.
 newtype Scheme = Scheme NonEmptyString
 
-derive newtype instance eqScheme ∷ Eq Scheme
-derive newtype instance ordScheme ∷ Ord Scheme
+derive newtype instance eqScheme :: Eq Scheme
+derive newtype instance ordScheme :: Ord Scheme
 
-instance showScheme ∷ Show Scheme where
+instance showScheme :: Show Scheme where
   show (Scheme s) = "(Scheme.unsafeFromString " <> show (NES.toString s) <> ")"
 
 -- | Attempts to create a `Scheme` from the passed string. The scheme component
@@ -40,7 +40,7 @@ instance showScheme ∷ Show Scheme where
 -- | fromString "!!!" == Nothing
 -- | fromString "" == Nothing
 -- | ```
-fromString ∷ String → Maybe Scheme
+fromString :: String -> Maybe Scheme
 fromString = map Scheme <<< hush <<< flip runParser (parseScheme <* eof)
 
 -- | Returns the string value for a scheme.
@@ -49,7 +49,7 @@ fromString = map Scheme <<< hush <<< flip runParser (parseScheme <* eof)
 -- | toString (unsafeFromString "http") == "http"
 -- | toString (unsafeFromString "git+ssh") == "git+ssh"
 -- | ```
-toString ∷ Scheme → NonEmptyString
+toString :: Scheme -> NonEmptyString
 toString (Scheme s) = s
 
 -- | Constructs a `Scheme` part unsafely: if the value is not an acceptable
@@ -57,23 +57,23 @@ toString (Scheme s) = s
 -- |
 -- | This is intended as a convenience when describing `Scheme`s statically in
 -- | PureScript code, in all other cases `fromString` should be used.
-unsafeFromString ∷ String → Scheme
+unsafeFromString :: String -> Scheme
 unsafeFromString s = case fromString s of
-  Just s' → s'
-  Nothing → unsafeCrashWith $ "Scheme value is invalid: `" <> show s <> "`"
+  Just s' -> s'
+  Nothing -> unsafeCrashWith $ "Scheme value is invalid: `" <> show s <> "`"
 
 -- | A parser for the scheme component of a URI. Expects a scheme string
 -- | followed by `':'`.
-parser ∷ Parser String Scheme
+parser :: Parser String Scheme
 parser = Scheme <$> parseScheme <* char ':'
 
-parseScheme ∷ Parser String NonEmptyString
+parseScheme :: Parser String NonEmptyString
 parseScheme = do
-  init ← alpha
-  rest ← NES.joinWith "" <$> List.manyRec (NES.singleton <$> (alphaNum <|> char '+' <|> char '-' <|> char '.'))
+  init <- alpha
+  rest <- NES.joinWith "" <$> List.manyRec (NES.singleton <$> (alphaNum <|> char '+' <|> char '-' <|> char '.'))
   pure $ NES.singleton init `NES.appendString` rest
 
 -- | A printer for the scheme component of a URI. Prints a scheme value
 -- | followed by a `':'`.
-print ∷ Scheme → String
+print :: Scheme -> String
 print (Scheme s) = NES.toString s <> ":"

--- a/src/URI/Scheme/Common.purs
+++ b/src/URI/Scheme/Common.purs
@@ -5,373 +5,373 @@ module URI.Scheme.Common where
 import URI.Scheme (Scheme, unsafeFromString)
 
 -- | Diameter Protocol ([RFC6733](https://tools.ietf.org/html/rfc6733))
-aaa ∷ Scheme
+aaa :: Scheme
 aaa = unsafeFromString "aaa"
 
 -- | Diameter Protocol with Secure ([RFC6733](https://tools.ietf.org/html/rfc6733))
-aaas ∷ Scheme
+aaas :: Scheme
 aaas = unsafeFromString "aaas"
 
 -- | about ([RFC6694](https://tools.ietf.org/html/rfc6694))
-about ∷ Scheme
+about :: Scheme
 about = unsafeFromString "about"
 
 -- | application configuration access ([RFC2244](https://tools.ietf.org/html/rfc2244))
-acap ∷ Scheme
+acap :: Scheme
 acap = unsafeFromString "acap"
 
 -- | acct ([RFC7565](https://tools.ietf.org/html/rfc7565))
-acct ∷ Scheme
+acct :: Scheme
 acct = unsafeFromString "acct"
 
 -- | Calendar Access Protocol ([RFC4324](https://tools.ietf.org/html/rfc4324))
-cap ∷ Scheme
+cap :: Scheme
 cap = unsafeFromString "cap"
 
 -- | content identifier ([RFC2392](https://tools.ietf.org/html/rfc2392))
-cid ∷ Scheme
+cid :: Scheme
 cid = unsafeFromString "cid"
 
 -- | coap ([RFC7252](https://tools.ietf.org/html/rfc7252))
-coap ∷ Scheme
+coap :: Scheme
 coap = unsafeFromString "coap"
 
 -- | coap+tcp ([RFC8323](https://tools.ietf.org/html/rfc8323))
-coaptcp ∷ Scheme
+coaptcp :: Scheme
 coaptcp = unsafeFromString "coap+tcp"
 
 -- | coap+ws ([RFC8323](https://tools.ietf.org/html/rfc8323))
-coapws ∷ Scheme
+coapws :: Scheme
 coapws = unsafeFromString "coap+ws"
 
 -- | coaps ([RFC7252](https://tools.ietf.org/html/rfc7252))
-coaps ∷ Scheme
+coaps :: Scheme
 coaps = unsafeFromString "coaps"
 
 -- | coaps+tcp ([RFC8323](https://tools.ietf.org/html/rfc8323))
-coapstcp ∷ Scheme
+coapstcp :: Scheme
 coapstcp = unsafeFromString "coaps+tcp"
 
 -- | coaps+ws ([RFC8323](https://tools.ietf.org/html/rfc8323))
-coapsws ∷ Scheme
+coapsws :: Scheme
 coapsws = unsafeFromString "coaps+ws"
 
 -- | TV-Anytime Content Reference ([RFC4078](https://tools.ietf.org/html/rfc4078))
-crid ∷ Scheme
+crid :: Scheme
 crid = unsafeFromString "crid"
 
 -- | data ([RFC2397](https://tools.ietf.org/html/rfc2397))
-data_ ∷ Scheme
+data_ :: Scheme
 data_ = unsafeFromString "data"
 
 -- | dav ([RFC4918](https://tools.ietf.org/html/rfc4918))
-dav ∷ Scheme
+dav :: Scheme
 dav = unsafeFromString "dav"
 
 -- | dictionary service protocol ([RFC2229](https://tools.ietf.org/html/rfc2229))
-dict ∷ Scheme
+dict :: Scheme
 dict = unsafeFromString "dict"
 
 -- | Domain Name System ([RFC4501](https://tools.ietf.org/html/rfc4501))
-dns ∷ Scheme
+dns :: Scheme
 dns = unsafeFromString "dns"
 
 -- | example ([RFC7595](https://tools.ietf.org/html/rfc7595))
-example ∷ Scheme
+example :: Scheme
 example = unsafeFromString "example"
 
 -- | Host-specific file names ([RFC8089](https://tools.ietf.org/html/rfc8089))
-file ∷ Scheme
+file :: Scheme
 file = unsafeFromString "file"
 
 -- | File Transfer Protocol ([RFC1738](https://tools.ietf.org/html/rfc1738))
-ftp ∷ Scheme
+ftp :: Scheme
 ftp = unsafeFromString "ftp"
 
 -- | Geographic Locations ([RFC5870](https://tools.ietf.org/html/rfc5870))
-geo ∷ Scheme
+geo :: Scheme
 geo = unsafeFromString "geo"
 
 -- | go ([RFC3368](https://tools.ietf.org/html/rfc3368))
-go ∷ Scheme
+go :: Scheme
 go = unsafeFromString "go"
 
 -- | The Gopher Protocol ([RFC4266](https://tools.ietf.org/html/rfc4266))
-gopher ∷ Scheme
+gopher :: Scheme
 gopher = unsafeFromString "gopher"
 
 -- | H.323 ([RFC3508](https://tools.ietf.org/html/rfc3508))
-h323 ∷ Scheme
+h323 :: Scheme
 h323 = unsafeFromString "h323"
 
 -- | Hypertext Transfer Protocol ([RFC7230, Section 2.7.1](https://tools.ietf.org/html/rfc7230#section-2.7.1))
-http ∷ Scheme
+http :: Scheme
 http = unsafeFromString "http"
 
 -- | Hypertext Transfer Protocol Secure ([RFC7230, Section 2.7.2](https://tools.ietf.org/html/rfc7230#section-2.7.2))
-https ∷ Scheme
+https :: Scheme
 https = unsafeFromString "https"
 
 -- | Inter-Asterisk eXchange Version 2 ([RFC5456](https://tools.ietf.org/html/rfc5456))
-iax ∷ Scheme
+iax :: Scheme
 iax = unsafeFromString "iax"
 
 -- | Internet Content Adaptation Protocol ([RFC3507](https://tools.ietf.org/html/rfc3507))
-icap ∷ Scheme
+icap :: Scheme
 icap = unsafeFromString "icap"
 
 -- | Instant Messaging ([RFC3860](https://tools.ietf.org/html/rfc3860))
-im ∷ Scheme
+im :: Scheme
 im = unsafeFromString "im"
 
 -- | internet message access protocol ([RFC5092](https://tools.ietf.org/html/rfc5092))
-imap ∷ Scheme
+imap :: Scheme
 imap = unsafeFromString "imap"
 
 -- | registry of public namespaces, which ([RFC4452](https://tools.ietf.org/html/rfc4452))
-info ∷ Scheme
+info :: Scheme
 info = unsafeFromString "info"
 
 -- | Internet Printing Protocol ([RFC3510](https://tools.ietf.org/html/rfc3510))
-ipp ∷ Scheme
+ipp :: Scheme
 ipp = unsafeFromString "ipp"
 
 -- | Internet Printing Protocol over ([RFC7472](https://tools.ietf.org/html/rfc7472))
-ipps ∷ Scheme
+ipps :: Scheme
 ipps = unsafeFromString "ipps"
 
 -- | Internet Registry Information ([RFC3981](https://tools.ietf.org/html/rfc3981))
-iris ∷ Scheme
+iris :: Scheme
 iris = unsafeFromString "iris"
 
 -- | iris.beep ([RFC3983](https://tools.ietf.org/html/rfc3983))
-irisbeep ∷ Scheme
+irisbeep :: Scheme
 irisbeep = unsafeFromString "iris.beep"
 
 -- | iris.lwz ([RFC4993](https://tools.ietf.org/html/rfc4993))
-irislwz ∷ Scheme
+irislwz :: Scheme
 irislwz = unsafeFromString "iris.lwz"
 
 -- | iris.xpc ([RFC4992](https://tools.ietf.org/html/rfc4992))
-irisxpc ∷ Scheme
+irisxpc :: Scheme
 irisxpc = unsafeFromString "iris.xpc"
 
 -- | iris.xpcs ([RFC4992](https://tools.ietf.org/html/rfc4992))
-irisxpcs ∷ Scheme
+irisxpcs :: Scheme
 irisxpcs = unsafeFromString "iris.xpcs"
 
 -- | Lightweight Directory Access ([RFC4516](https://tools.ietf.org/html/rfc4516))
-ldap ∷ Scheme
+ldap :: Scheme
 ldap = unsafeFromString "ldap"
 
 -- | Electronic mail address ([RFC6068](https://tools.ietf.org/html/rfc6068))
-mailto ∷ Scheme
+mailto :: Scheme
 mailto = unsafeFromString "mailto"
 
 -- | message identifier ([RFC2392](https://tools.ietf.org/html/rfc2392))
-mid ∷ Scheme
+mid :: Scheme
 mid = unsafeFromString "mid"
 
 -- | Message Session Relay Protocol ([RFC4975](https://tools.ietf.org/html/rfc4975))
-msrp ∷ Scheme
+msrp :: Scheme
 msrp = unsafeFromString "msrp"
 
 -- | Message Session Relay Protocol ([RFC4975](https://tools.ietf.org/html/rfc4975))
-msrps ∷ Scheme
+msrps :: Scheme
 msrps = unsafeFromString "msrps"
 
 -- | Message Tracking Query Protocol ([RFC3887](https://tools.ietf.org/html/rfc3887))
-mtqp ∷ Scheme
+mtqp :: Scheme
 mtqp = unsafeFromString "mtqp"
 
 -- | Mailbox Update (MUPDATE) Protocol ([RFC3656](https://tools.ietf.org/html/rfc3656))
-mupdate ∷ Scheme
+mupdate :: Scheme
 mupdate = unsafeFromString "mupdate"
 
 -- | USENET news ([RFC5538](https://tools.ietf.org/html/rfc5538))
-news ∷ Scheme
+news :: Scheme
 news = unsafeFromString "news"
 
 -- | network file system protocol ([RFC2224](https://tools.ietf.org/html/rfc2224))
-nfs ∷ Scheme
+nfs :: Scheme
 nfs = unsafeFromString "nfs"
 
 -- | ni ([RFC6920](https://tools.ietf.org/html/rfc6920))
-ni ∷ Scheme
+ni :: Scheme
 ni = unsafeFromString "ni"
 
 -- | nih ([RFC6920](https://tools.ietf.org/html/rfc6920))
-nih ∷ Scheme
+nih :: Scheme
 nih = unsafeFromString "nih"
 
 -- | USENET news using NNTP access ([RFC5538](https://tools.ietf.org/html/rfc5538))
-nntp ∷ Scheme
+nntp :: Scheme
 nntp = unsafeFromString "nntp"
 
 -- | opaquelocktokent ([RFC4918](https://tools.ietf.org/html/rfc4918))
-opaquelocktoken ∷ Scheme
+opaquelocktoken :: Scheme
 opaquelocktoken = unsafeFromString "opaquelocktoken"
 
 -- | PKCS#11 ([RFC7512](https://tools.ietf.org/html/rfc7512))
-pkcs11 ∷ Scheme
+pkcs11 :: Scheme
 pkcs11 = unsafeFromString "pkcs11"
 
 -- | Post Office Protocol v3 ([RFC2384](https://tools.ietf.org/html/rfc2384))
-pop ∷ Scheme
+pop :: Scheme
 pop = unsafeFromString "pop"
 
 -- | Presence ([RFC3859](https://tools.ietf.org/html/rfc3859))
-pres ∷ Scheme
+pres :: Scheme
 pres = unsafeFromString "pres"
 
 -- | reload ([RFC6940](https://tools.ietf.org/html/rfc6940))
-reload ∷ Scheme
+reload :: Scheme
 reload = unsafeFromString "reload"
 
 -- | Real-Time Streaming Protocol (RTSP) ([RFC2326](https://tools.ietf.org/html/rfc2326), [RFC7826](https://tools.ietf.org/html/rfc7826))
-rtsp ∷ Scheme
+rtsp :: Scheme
 rtsp = unsafeFromString "rtsp"
 
 -- | Real-Time Streaming Protocol (RTSP) ([RFC2326](https://tools.ietf.org/html/rfc2326), [RFC7826](https://tools.ietf.org/html/rfc7826))
-rtsps ∷ Scheme
+rtsps :: Scheme
 rtsps = unsafeFromString "rtsps"
 
 -- | Real-Time Streaming Protocol (RTSP) ([RFC2326](https://tools.ietf.org/html/rfc2326))
-rtspu ∷ Scheme
+rtspu :: Scheme
 rtspu = unsafeFromString "rtspu"
 
 -- | service location ([RFC2609](https://tools.ietf.org/html/rfc2609))
-service ∷ Scheme
+service :: Scheme
 service = unsafeFromString "service"
 
 -- | session ([RFC6787](https://tools.ietf.org/html/rfc6787))
-session ∷ Scheme
+session :: Scheme
 session = unsafeFromString "session"
 
 -- | Secure Hypertext Transfer Protocol ([RFC2660](https://tools.ietf.org/html/rfc2660))
-shttp ∷ Scheme
+shttp :: Scheme
 shttp = unsafeFromString "shttp"
 
 -- | ManageSieve Protocol ([RFC5804](https://tools.ietf.org/html/rfc5804))
-sieve ∷ Scheme
+sieve :: Scheme
 sieve = unsafeFromString "sieve"
 
 -- | session initiation protocol ([RFC3261](https://tools.ietf.org/html/rfc3261))
-sip ∷ Scheme
+sip :: Scheme
 sip = unsafeFromString "sip"
 
 -- | secure session initiation protocol ([RFC3261](https://tools.ietf.org/html/rfc3261))
-sips ∷ Scheme
+sips :: Scheme
 sips = unsafeFromString "sips"
 
 -- | Short Message Service ([RFC5724](https://tools.ietf.org/html/rfc5724))
-sms ∷ Scheme
+sms :: Scheme
 sms = unsafeFromString "sms"
 
 -- | Simple Network Management Protocol ([RFC4088](https://tools.ietf.org/html/rfc4088))
-snmp ∷ Scheme
+snmp :: Scheme
 snmp = unsafeFromString "snmp"
 
 -- | soap.beep ([RFC4227](https://tools.ietf.org/html/rfc4227))
-soapbeep ∷ Scheme
+soapbeep :: Scheme
 soapbeep = unsafeFromString "soap.beep"
 
 -- | soap.beeps ([RFC4227](https://tools.ietf.org/html/rfc4227))
-soapbeeps ∷ Scheme
+soapbeeps :: Scheme
 soapbeeps = unsafeFromString "soap.beeps"
 
 -- | stun ([RFC7064](https://tools.ietf.org/html/rfc7064))
-stun ∷ Scheme
+stun :: Scheme
 stun = unsafeFromString "stun"
 
 -- | stuns ([RFC7064](https://tools.ietf.org/html/rfc7064))
-stuns ∷ Scheme
+stuns :: Scheme
 stuns = unsafeFromString "stuns"
 
 -- | tag ([RFC4151](https://tools.ietf.org/html/rfc4151))
-tag ∷ Scheme
+tag :: Scheme
 tag = unsafeFromString "tag"
 
 -- | telephone ([RFC3966](https://tools.ietf.org/html/rfc3966))
-tel ∷ Scheme
+tel :: Scheme
 tel = unsafeFromString "tel"
 
 -- | Reference to interactive sessions ([RFC4248](https://tools.ietf.org/html/rfc4248))
-telnet ∷ Scheme
+telnet :: Scheme
 telnet = unsafeFromString "telnet"
 
 -- | Trivial File Transfer Protocol ([RFC3617](https://tools.ietf.org/html/rfc3617))
-tftp ∷ Scheme
+tftp :: Scheme
 tftp = unsafeFromString "tftp"
 
 -- | multipart/related relative reference ([RFC2557](https://tools.ietf.org/html/rfc2557))
-thismessage ∷ Scheme
+thismessage :: Scheme
 thismessage = unsafeFromString "thismessage"
 
 -- | Transaction Internet Protocol ([RFC2371](https://tools.ietf.org/html/rfc2371))
-tip ∷ Scheme
+tip :: Scheme
 tip = unsafeFromString "tip"
 
 -- | Interactive 3270 emulation sessions ([RFC6270](https://tools.ietf.org/html/rfc6270))
-tn3270 ∷ Scheme
+tn3270 :: Scheme
 tn3270 = unsafeFromString "tn3270"
 
 -- | turn ([RFC7065](https://tools.ietf.org/html/rfc7065))
-turn ∷ Scheme
+turn :: Scheme
 turn = unsafeFromString "turn"
 
 -- | turns ([RFC7065](https://tools.ietf.org/html/rfc7065))
-turns ∷ Scheme
+turns :: Scheme
 turns = unsafeFromString "turns"
 
 -- | TV Broadcasts ([RFC2838](https://tools.ietf.org/html/rfc2838))
-tv ∷ Scheme
+tv :: Scheme
 tv = unsafeFromString "tv"
 
 -- | Uniform Resource Names ([RFC8141](https://tools.ietf.org/html/rfc8141))
-urn ∷ Scheme
+urn :: Scheme
 urn = unsafeFromString "urn"
 
 -- | versatile multimedia interface ([RFC2122](https://tools.ietf.org/html/rfc2122))
-vemmi ∷ Scheme
+vemmi :: Scheme
 vemmi = unsafeFromString "vemmi"
 
 -- | Remote Framebuffer Protocol ([RFC7869](https://tools.ietf.org/html/rfc7869))
-vnc ∷ Scheme
+vnc :: Scheme
 vnc = unsafeFromString "vnc"
 
 -- | WebSocket connections ([RFC6455](https://tools.ietf.org/html/rfc6455))
-ws ∷ Scheme
+ws :: Scheme
 ws = unsafeFromString "ws"
 
 -- | Encrypted WebSocket connections ([RFC6455](https://tools.ietf.org/html/rfc6455))
-wss ∷ Scheme
+wss :: Scheme
 wss = unsafeFromString "wss"
 
 -- | xcon ([RFC6501](https://tools.ietf.org/html/rfc6501))
-xcon ∷ Scheme
+xcon :: Scheme
 xcon = unsafeFromString "xcon"
 
 -- | xcon-userid ([RFC6501](https://tools.ietf.org/html/rfc6501))
-xconuserid ∷ Scheme
+xconuserid :: Scheme
 xconuserid = unsafeFromString "xcon-userid"
 
 -- | xmlrpc.beep ([RFC3529](https://tools.ietf.org/html/rfc3529))
-xmlrpcbeep ∷ Scheme
+xmlrpcbeep :: Scheme
 xmlrpcbeep = unsafeFromString "xmlrpc.beep"
 
 -- | xmlrpc.beeps ([RFC3529](https://tools.ietf.org/html/rfc3529))
-xmlrpcbeeps ∷ Scheme
+xmlrpcbeeps :: Scheme
 xmlrpcbeeps = unsafeFromString "xmlrpc.beeps"
 
 -- | Extensible Messaging and Presence ([RFC5122](https://tools.ietf.org/html/rfc5122))
-xmpp ∷ Scheme
+xmpp :: Scheme
 xmpp = unsafeFromString "xmpp"
 
 -- | Z39.50 Retrieval ([RFC2056](https://tools.ietf.org/html/rfc2056))
-z3950r ∷ Scheme
+z3950r :: Scheme
 z3950r = unsafeFromString "z39.50r"
 
 -- | Z39.50 Session ([RFC2056](https://tools.ietf.org/html/rfc2056))
-z3950s ∷ Scheme
+z3950s :: Scheme
 z3950s = unsafeFromString "z39.50s"

--- a/src/URI/URI.purs
+++ b/src/URI/URI.purs
@@ -41,10 +41,11 @@ import URI.Scheme as Scheme
 -- | but is required to have a `Scheme` component.
 data URI userInfo hosts path hierPath query fragment = URI Scheme (HierarchicalPart userInfo hosts path hierPath) (Maybe query) (Maybe fragment)
 
-derive instance eqURI ∷ (Eq userInfo, Eq hosts, Eq path, Eq hierPath, Eq query, Eq fragment) ⇒ Eq (URI userInfo hosts path hierPath query fragment)
-derive instance ordURI ∷ (Ord userInfo, Ord hosts, Ord path, Ord hierPath, Ord query, Ord fragment) ⇒ Ord (URI userInfo hosts path hierPath query fragment)
-derive instance genericURI ∷ Generic (URI userInfo hosts path hierPath query fragment) _
-instance showURI ∷ (Show userInfo, Show hosts, Show path, Show hierPath, Show query, Show fragment) ⇒ Show (URI userInfo hosts path hierPath query fragment) where show = genericShow
+derive instance eqURI :: (Eq userInfo, Eq hosts, Eq path, Eq hierPath, Eq query, Eq fragment) => Eq (URI userInfo hosts path hierPath query fragment)
+derive instance ordURI :: (Ord userInfo, Ord hosts, Ord path, Ord hierPath, Ord query, Ord fragment) => Ord (URI userInfo hosts path hierPath query fragment)
+derive instance genericURI :: Generic (URI userInfo hosts path hierPath query fragment) _
+instance showURI :: (Show userInfo, Show hosts, Show path, Show hierPath, Show query, Show fragment) => Show (URI userInfo hosts path hierPath query fragment) where
+  show = genericShow
 
 -- | A row type for describing the options fields used by the URI parser and
 -- | printer.
@@ -68,12 +69,12 @@ type URIOptions userInfo hosts path hierPath query fragment =
 -- | `HostPortPair.parseHosts pure pure`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair parser.
 type URIParseOptions userInfo hosts path hierPath query fragment r =
-  ( parseUserInfo ∷ UserInfo → Either URIPartParseError userInfo
-  , parseHosts ∷ Parser String hosts
-  , parsePath ∷ Path → Either URIPartParseError path
-  , parseHierPath ∷ Either PathAbsolute PathRootless → Either URIPartParseError hierPath
-  , parseQuery ∷ Query → Either URIPartParseError query
-  , parseFragment ∷ Fragment → Either URIPartParseError fragment
+  ( parseUserInfo :: UserInfo -> Either URIPartParseError userInfo
+  , parseHosts :: Parser String hosts
+  , parsePath :: Path -> Either URIPartParseError path
+  , parseHierPath :: Either PathAbsolute PathRootless -> Either URIPartParseError hierPath
+  , parseQuery :: Query -> Either URIPartParseError query
+  , parseFragment :: Fragment -> Either URIPartParseError fragment
   | r
   )
 
@@ -88,20 +89,20 @@ type URIParseOptions userInfo hosts path hierPath query fragment r =
 -- | `HostPortPair.printHosts identity identity`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type URIPrintOptions userInfo hosts path hierPath query fragment r =
-  ( printUserInfo ∷ userInfo → UserInfo
-  , printHosts ∷ hosts → String
-  , printPath ∷ path → Path
-  , printHierPath ∷ hierPath → Either PathAbsolute PathRootless
-  , printQuery ∷ query → Query
-  , printFragment ∷ fragment → Fragment
+  ( printUserInfo :: userInfo -> UserInfo
+  , printHosts :: hosts -> String
+  , printPath :: path -> Path
+  , printHierPath :: hierPath -> Either PathAbsolute PathRootless
+  , printQuery :: query -> Query
+  , printFragment :: fragment -> Fragment
   | r
   )
 
 -- | A parser for a URI.
 parser
-  ∷ ∀ userInfo hosts path hierPath query fragment r
-  . Record (URIParseOptions userInfo hosts path hierPath query fragment r)
-  → Parser String (URI userInfo hosts path hierPath query fragment)
+  :: forall userInfo hosts path hierPath query fragment r
+   . Record (URIParseOptions userInfo hosts path hierPath query fragment r)
+  -> Parser String (URI userInfo hosts path hierPath query fragment)
 parser opts = URI
   <$> Scheme.parser
   <*> HPart.parser opts
@@ -111,10 +112,10 @@ parser opts = URI
 
 -- | A printer for a URI.
 print
-  ∷ ∀ userInfo hosts path hierPath query fragment r
-  . Record (URIPrintOptions userInfo hosts path hierPath query fragment r)
-  → URI userInfo hosts path hierPath query fragment
-  → String
+  :: forall userInfo hosts path hierPath query fragment r
+   . Record (URIPrintOptions userInfo hosts path hierPath query fragment r)
+  -> URI userInfo hosts path hierPath query fragment
+  -> String
 print opts (URI s h q f) =
   String.joinWith "" $ Array.catMaybes
     [ Just (Scheme.print s)
@@ -125,44 +126,44 @@ print opts (URI s h q f) =
 
 -- | The scheme component of a URI.
 _scheme
-  ∷ ∀ userInfo hosts path hierPath query fragment
-  . Lens'
-      (URI userInfo hosts path hierPath query fragment)
-      Scheme
+  :: forall userInfo hosts path hierPath query fragment
+   . Lens'
+       (URI userInfo hosts path hierPath query fragment)
+       Scheme
 _scheme =
   lens
-    (\(URI s _ _ _) → s)
-    (\(URI _ h q f) s → URI s h q f)
+    (\(URI s _ _ _) -> s)
+    (\(URI _ h q f) s -> URI s h q f)
 
 -- | The hierarchical-part component of a URI.
 _hierPart
-  ∷ ∀ userInfo hosts path hierPath query fragment
-  . Lens'
-      (URI userInfo hosts path hierPath query fragment)
-      (HierarchicalPart userInfo hosts path hierPath)
+  :: forall userInfo hosts path hierPath query fragment
+   . Lens'
+       (URI userInfo hosts path hierPath query fragment)
+       (HierarchicalPart userInfo hosts path hierPath)
 _hierPart =
   lens
-    (\(URI _ h _ _) → h)
-    (\(URI s _ q f) h → URI s h q f)
+    (\(URI _ h _ _) -> h)
+    (\(URI s _ q f) h -> URI s h q f)
 
 -- | The query component of a URI.
 _query
-  ∷ ∀ userInfo hosts path hierPath query fragment
-  . Lens'
-      (URI userInfo hosts path hierPath query fragment)
-      (Maybe query)
+  :: forall userInfo hosts path hierPath query fragment
+   . Lens'
+       (URI userInfo hosts path hierPath query fragment)
+       (Maybe query)
 _query =
   lens
-    (\(URI _ _ q _) → q)
-    (\(URI s h _ f) q → URI s h q f)
+    (\(URI _ _ q _) -> q)
+    (\(URI s h _ f) q -> URI s h q f)
 
 -- | The fragment component of a URI.
 _fragment
-  ∷ ∀ userInfo hosts path hierPath query fragment
-  . Lens'
-      (URI userInfo hosts path hierPath query fragment)
-      (Maybe fragment)
+  :: forall userInfo hosts path hierPath query fragment
+   . Lens'
+       (URI userInfo hosts path hierPath query fragment)
+       (Maybe fragment)
 _fragment =
   lens
-    (\(URI _ _ _ f) → f)
-    (\(URI s h q _) f → URI s h q f)
+    (\(URI _ _ _ f) -> f)
+    (\(URI s h q _) f -> URI s h q f)

--- a/src/URI/URI.purs
+++ b/src/URI/URI.purs
@@ -103,12 +103,13 @@ parser
   :: forall userInfo hosts path hierPath query fragment r
    . Record (URIParseOptions userInfo hosts path hierPath query fragment r)
   -> Parser String (URI userInfo hosts path hierPath query fragment)
-parser opts = URI
-  <$> Scheme.parser
-  <*> HPart.parser opts
-  <*> optionMaybe (wrapParser opts.parseQuery Query.parser)
-  <*> optionMaybe (wrapParser opts.parseFragment Fragment.parser)
-  <* eof
+parser opts =
+  URI
+    <$> Scheme.parser
+    <*> HPart.parser opts
+    <*> optionMaybe (wrapParser opts.parseQuery Query.parser)
+    <*> optionMaybe (wrapParser opts.parseFragment Fragment.parser)
+    <* eof
 
 -- | A printer for a URI.
 print
@@ -125,44 +126,28 @@ print opts (URI s h q f) =
     ]
 
 -- | The scheme component of a URI.
-_scheme
-  :: forall userInfo hosts path hierPath query fragment
-   . Lens'
-       (URI userInfo hosts path hierPath query fragment)
-       Scheme
+_scheme :: forall userInfo hosts path hierPath query fragment. Lens' (URI userInfo hosts path hierPath query fragment) Scheme
 _scheme =
   lens
     (\(URI s _ _ _) -> s)
     (\(URI _ h q f) s -> URI s h q f)
 
 -- | The hierarchical-part component of a URI.
-_hierPart
-  :: forall userInfo hosts path hierPath query fragment
-   . Lens'
-       (URI userInfo hosts path hierPath query fragment)
-       (HierarchicalPart userInfo hosts path hierPath)
+_hierPart :: forall userInfo hosts path hierPath query fragment. Lens' (URI userInfo hosts path hierPath query fragment) (HierarchicalPart userInfo hosts path hierPath)
 _hierPart =
   lens
     (\(URI _ h _ _) -> h)
     (\(URI s _ q f) h -> URI s h q f)
 
 -- | The query component of a URI.
-_query
-  :: forall userInfo hosts path hierPath query fragment
-   . Lens'
-       (URI userInfo hosts path hierPath query fragment)
-       (Maybe query)
+_query :: forall userInfo hosts path hierPath query fragment. Lens' (URI userInfo hosts path hierPath query fragment) (Maybe query)
 _query =
   lens
     (\(URI _ _ q _) -> q)
     (\(URI s h _ f) q -> URI s h q f)
 
 -- | The fragment component of a URI.
-_fragment
-  :: forall userInfo hosts path hierPath query fragment
-   . Lens'
-       (URI userInfo hosts path hierPath query fragment)
-       (Maybe fragment)
+_fragment :: forall userInfo hosts path hierPath query fragment. Lens' (URI userInfo hosts path hierPath query fragment) (Maybe fragment)
 _fragment =
   lens
     (\(URI _ _ _ f) -> f)

--- a/src/URI/URIRef.purs
+++ b/src/URI/URIRef.purs
@@ -109,8 +109,7 @@ parser
   :: forall userInfo hosts path hierPath relPath query fragment r
    . Record (URIRefParseOptions userInfo hosts path hierPath relPath query fragment r)
   -> Parser String (URIRef userInfo hosts path hierPath relPath query fragment)
-parser opts = try (Left <$> URI.parser opts)
-  <|> (Right <$> RelativeRef.parser opts)
+parser opts = try (Left <$> URI.parser opts) <|> (Right <$> RelativeRef.parser opts)
 
 -- | A printer for a general URI.
 print

--- a/src/URI/URIRef.purs
+++ b/src/URI/URIRef.purs
@@ -72,13 +72,13 @@ type URIRefOptions userInfo hosts path hierPath relPath query fragment =
 -- | `HostPortPair.parseHosts pure pure`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair parser.
 type URIRefParseOptions userInfo hosts path hierPath relPath query fragment r =
-  ( parseUserInfo ∷ UserInfo → Either URIPartParseError userInfo
-  , parseHosts ∷ Parser String hosts
-  , parsePath ∷ Path → Either URIPartParseError path
-  , parseHierPath ∷ Either PathAbsolute PathRootless → Either URIPartParseError hierPath
-  , parseRelPath ∷ Either PathAbsolute PathNoScheme → Either URIPartParseError relPath
-  , parseQuery ∷ Query → Either URIPartParseError query
-  , parseFragment ∷ Fragment → Either URIPartParseError fragment
+  ( parseUserInfo :: UserInfo -> Either URIPartParseError userInfo
+  , parseHosts :: Parser String hosts
+  , parsePath :: Path -> Either URIPartParseError path
+  , parseHierPath :: Either PathAbsolute PathRootless -> Either URIPartParseError hierPath
+  , parseRelPath :: Either PathAbsolute PathNoScheme -> Either URIPartParseError relPath
+  , parseQuery :: Query -> Either URIPartParseError query
+  , parseFragment :: Fragment -> Either URIPartParseError fragment
   | r
   )
 
@@ -94,29 +94,28 @@ type URIRefParseOptions userInfo hosts path hierPath relPath query fragment r =
 -- | `HostPortPair.printHosts id id`. See [`URI.HostPortPair`](../URI.HostPortPair)
 -- | for more information on the host/port pair printer.
 type URIRefPrintOptions userInfo hosts path hierPath relPath query fragment r =
-  ( printUserInfo ∷ userInfo → UserInfo
-  , printHosts ∷ hosts → String
-  , printPath ∷ path → Path
-  , printHierPath ∷ hierPath → Either PathAbsolute PathRootless
-  , printRelPath ∷ relPath → Either PathAbsolute PathNoScheme
-  , printQuery ∷ query → Query
-  , printFragment ∷ fragment → Fragment
+  ( printUserInfo :: userInfo -> UserInfo
+  , printHosts :: hosts -> String
+  , printPath :: path -> Path
+  , printHierPath :: hierPath -> Either PathAbsolute PathRootless
+  , printRelPath :: relPath -> Either PathAbsolute PathNoScheme
+  , printQuery :: query -> Query
+  , printFragment :: fragment -> Fragment
   | r
   )
 
 -- | A parser for a general URI.
 parser
-  ∷ ∀ userInfo hosts path hierPath relPath query fragment r
-  . Record (URIRefParseOptions userInfo hosts path hierPath relPath query fragment r)
-  → Parser String (URIRef userInfo hosts path hierPath relPath query fragment)
-parser opts
-  = try (Left <$> URI.parser opts)
+  :: forall userInfo hosts path hierPath relPath query fragment r
+   . Record (URIRefParseOptions userInfo hosts path hierPath relPath query fragment r)
+  -> Parser String (URIRef userInfo hosts path hierPath relPath query fragment)
+parser opts = try (Left <$> URI.parser opts)
   <|> (Right <$> RelativeRef.parser opts)
 
 -- | A printer for a general URI.
 print
-  ∷ ∀ userInfo hosts path hierPath relPath query fragment r
-  . Record (URIRefPrintOptions userInfo hosts path hierPath relPath query fragment r)
-  → URIRef userInfo hosts path hierPath relPath query fragment
-  → String
+  :: forall userInfo hosts path hierPath relPath query fragment r
+   . Record (URIRefPrintOptions userInfo hosts path hierPath relPath query fragment r)
+  -> URIRef userInfo hosts path hierPath relPath query fragment
+  -> String
 print opts = either (URI.print opts) (RelativeRef.print opts)

--- a/src/URI/UserInfo.purs
+++ b/src/URI/UserInfo.purs
@@ -27,11 +27,11 @@ import URI.Common (decodeURIComponent', subDelims, unreserved, pctEncoded, print
 -- | look at `URI.Extra.UserPassInfo`.
 newtype UserInfo = UserInfo NonEmptyString
 
-derive newtype instance eqUserInfo ∷ Eq UserInfo
-derive newtype instance ordUserInfo ∷ Ord UserInfo
-derive newtype instance semigroupUserInfo ∷ Semigroup UserInfo
+derive newtype instance eqUserInfo :: Eq UserInfo
+derive newtype instance ordUserInfo :: Ord UserInfo
+derive newtype instance semigroupUserInfo :: Semigroup UserInfo
 
-instance showUserInfo ∷ Show UserInfo where
+instance showUserInfo :: Show UserInfo where
   show (UserInfo s) = "(UserInfo.unsafeFromString " <> show s <> ")"
 
 -- | Constructs a user-info value from a string, percent-encoding any characters
@@ -44,7 +44,7 @@ instance showUserInfo ∷ Show UserInfo where
 -- | fromString "foo@bar" = unsafeFromString "foo%40bar"
 -- | fromString "foo%40bar" = unsafeFromString "foo%2540bar"
 -- | ```
-fromString ∷ NonEmptyString → UserInfo
+fromString :: NonEmptyString -> UserInfo
 fromString = UserInfo <<< printEncoded' userInfoChar
 
 -- | Returns the string value for user-info, percent-decoding any characters
@@ -54,33 +54,33 @@ fromString = UserInfo <<< printEncoded' userInfoChar
 -- | toString (unsafeFromString "foo") = "foo"
 -- | toString (unsafeFromString "foo%40bar") = "foo@bar"
 -- | ```
-toString ∷ UserInfo → NonEmptyString
+toString :: UserInfo -> NonEmptyString
 toString (UserInfo s) = decodeURIComponent' s
 
 -- | Constructs a user-info value from a string directly - no percent-encoding
 -- | will be applied. This is useful when using a custom encoding scheme for
 -- | the query, to prevent double-encoding.
-unsafeFromString ∷ NonEmptyString → UserInfo
+unsafeFromString :: NonEmptyString -> UserInfo
 unsafeFromString = UserInfo
 
 -- | Returns the string value for user-info without percent-decoding. Only
 -- | "unsafe" in the sense that values this produces may need further decoding,
 -- | the name is more for symmetry with the `fromString`/`unsafeFromString`
 -- | pairing.
-unsafeToString ∷ UserInfo → NonEmptyString
+unsafeToString :: UserInfo -> NonEmptyString
 unsafeToString (UserInfo s) = s
 
 -- | A parser for the user-info component of a URI.
-parser ∷ Parser String UserInfo
+parser :: Parser String UserInfo
 parser = UserInfo <<< NES.join1With "" <$> NEA.some parse
   where
-  parse ∷ Parser String NonEmptyString
+  parse :: Parser String NonEmptyString
   parse = NES.singleton <$> userInfoChar <|> pctEncoded
 
 -- | A printer for the user-info component of a URI.
-print ∷ UserInfo → String
+print :: UserInfo -> String
 print = NES.toString <<< unsafeToString
 
 -- | The supported user info characters, excluding percent-encodings.
-userInfoChar ∷ Parser String Char
+userInfoChar :: Parser String Char
 userInfoChar = unreserved <|> subDelims <|> char ':'

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -18,7 +18,7 @@ import Test.URI.Scheme as Scheme
 import Test.URI.URIRef as URIRef
 import Test.URI.UserInfo as UserInfo
 
-main ∷ Effect Unit
+main :: Effect Unit
 main = launchAff_ $ flip runReaderT 0 do
   Scheme.spec
   UserInfo.spec

--- a/test/Spec.purs
+++ b/test/Spec.purs
@@ -28,8 +28,7 @@ it :: String -> Spec Unit -> Spec Unit
 it = describe
 
 shouldEqual :: forall m a. MonadEffect m => Eq a => Show a => a -> a -> m Unit
-shouldEqual actual expected =
-  liftEffect $ assertEqual { actual, expected }
+shouldEqual actual expected = liftEffect $ assertEqual { actual, expected }
 
 fail :: forall m. MonadThrow Error m => String -> m Unit
 fail = throwError <<< error

--- a/test/URI/AbsoluteURI.purs
+++ b/test/URI/AbsoluteURI.purs
@@ -20,56 +20,66 @@ import URI.Port as Port
 import URI.Query as Query
 import URI.Scheme as Scheme
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "AbsoluteURI parser/printer" do
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
       "couchbase://localhost/testBucket?password=&docTypeKey="
-      (AbsoluteURI
-        (Scheme.unsafeFromString "couchbase")
-        (HierarchicalPartAuth
-          (Authority
-            Nothing
-            (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-          (path ["testBucket"]))
-        (Just (Query.unsafeFromString "password=&docTypeKey=")))
+      ( AbsoluteURI
+          (Scheme.unsafeFromString "couchbase")
+          ( HierarchicalPartAuth
+              ( Authority
+                  Nothing
+                  (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+              )
+              (path [ "testBucket" ])
+          )
+          (Just (Query.unsafeFromString "password=&docTypeKey="))
+      )
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
       "couchbase://localhost:9999/testBucket?password=pass&docTypeKey=type&queryTimeoutSeconds=20"
-      (AbsoluteURI
-        (Scheme.unsafeFromString "couchbase")
-        (HierarchicalPartAuth
-          (Authority
-            Nothing
-            (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))) (Port.unsafeFromInt 9999))))
-          (path ["testBucket"]))
-        (Just (Query.unsafeFromString "password=pass&docTypeKey=type&queryTimeoutSeconds=20")))
+      ( AbsoluteURI
+          (Scheme.unsafeFromString "couchbase")
+          ( HierarchicalPartAuth
+              ( Authority
+                  Nothing
+                  (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))) (Port.unsafeFromInt 9999)))
+              )
+              (path [ "testBucket" ])
+          )
+          (Just (Query.unsafeFromString "password=pass&docTypeKey=type&queryTimeoutSeconds=20"))
+      )
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
       "foo:/abc/def"
-      (AbsoluteURI
-        (Scheme.unsafeFromString "foo")
-        (HierarchicalPartNoAuth
-          (Just (Left (PathAbsolute (Just (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "abc")) [PathSegment.unsafeSegmentFromString "def"]))))))
-        Nothing)
+      ( AbsoluteURI
+          (Scheme.unsafeFromString "foo")
+          ( HierarchicalPartNoAuth
+              (Just (Left (PathAbsolute (Just (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "abc")) [ PathSegment.unsafeSegmentFromString "def" ])))))
+          )
+          Nothing
+      )
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
       "foo:abc/def"
-      (AbsoluteURI
-        (Scheme.unsafeFromString "foo")
-        (HierarchicalPartNoAuth
-          (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "abc")) [PathSegment.unsafeSegmentFromString "def"])))))
-        Nothing)
+      ( AbsoluteURI
+          (Scheme.unsafeFromString "foo")
+          ( HierarchicalPartNoAuth
+              (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "abc")) [ PathSegment.unsafeSegmentFromString "def" ]))))
+          )
+          Nothing
+      )
 
-path ∷ Array String → Path
+path :: Array String -> Path
 path = Path <<< map PathSegment.unsafeSegmentFromString
 
-options ∷ Record (AbsoluteURIOptions UserInfo (HostPortPair Host Port) Path HierPath Query)
+options :: Record (AbsoluteURIOptions UserInfo (HostPortPair Host Port) Path HierPath Query)
 options =
   { parseUserInfo: pure
   , printUserInfo: identity

--- a/test/URI/AbsoluteURI.purs
+++ b/test/URI/AbsoluteURI.purs
@@ -38,6 +38,7 @@ spec =
           )
           (Just (Query.unsafeFromString "password=&docTypeKey="))
       )
+
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
@@ -53,6 +54,7 @@ spec =
           )
           (Just (Query.unsafeFromString "password=pass&docTypeKey=type&queryTimeoutSeconds=20"))
       )
+
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)
@@ -64,6 +66,7 @@ spec =
           )
           Nothing
       )
+
     testIso
       (AbsoluteURI.parser options)
       (AbsoluteURI.print options)

--- a/test/URI/Authority.purs
+++ b/test/URI/Authority.purs
@@ -27,6 +27,7 @@ spec =
           Nothing
           (Just (This (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost"))))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -35,6 +36,7 @@ spec =
           Nothing
           (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000)))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -43,6 +45,7 @@ spec =
           (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "user"))))
           (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000)))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)

--- a/test/URI/Authority.purs
+++ b/test/URI/Authority.purs
@@ -16,37 +16,40 @@ import URI.HostPortPair as HostPortPair
 import URI.Port as Port
 import URI.UserInfo as UserInfo
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "Authority parser/printer" do
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//localhost"
-      (Authority
-        Nothing
-        (Just (This (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))))))
+      ( Authority
+          Nothing
+          (Just (This (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost"))))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//localhost:3000"
-      (Authority
-        Nothing
-        (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000))))
+      ( Authority
+          Nothing
+          (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000)))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user@localhost:3000"
-      (Authority
-        (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "user"))))
-        (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000))))
+      ( Authority
+          (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "user"))))
+          (Just (Both (NameAddress (RegName.unsafeFromString (nes (Proxy :: Proxy "localhost")))) (Port.unsafeFromInt 3000)))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//:8000"
       (Authority Nothing (Just (That (Port.unsafeFromInt 8000))))
 
-options ∷ Record (AuthorityOptions UserInfo (HostPortPair Host Port))
+options :: Record (AuthorityOptions UserInfo (HostPortPair Host Port))
 options =
   { parseUserInfo: pure
   , printUserInfo: identity

--- a/test/URI/Extra/MultiHostPortPair.purs
+++ b/test/URI/Extra/MultiHostPortPair.purs
@@ -23,117 +23,135 @@ import URI.URIRef (Fragment, HierPath, HierarchicalPart(..), Path(..), Query, Re
 import URI.URIRef as URIRef
 import URI.UserInfo as UserInfo
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec = do
   describe "Authority+MultiHostPortPair parser/printer" do
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//mongo-1,mongo-2"
-      (Authority
-        Nothing
-        [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
-        , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
-        ])
+      ( Authority
+          Nothing
+          [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
+          , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
+          ]
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//mongo-1:2000,mongo-2:3000"
-      (Authority
-        Nothing
-        [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1"))) (Port.unsafeFromInt 2000)
-        , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
-        ])
+      ( Authority
+          Nothing
+          [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1"))) (Port.unsafeFromInt 2000)
+          , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
+          ]
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//mongo-1:2000,mongo-2"
-      (Authority
-        Nothing
-        [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1"))) (Port.unsafeFromInt 2000)
-        , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
-        ])
+      ( Authority
+          Nothing
+          [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1"))) (Port.unsafeFromInt 2000)
+          , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
+          ]
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//mongo-1,mongo-2:3000"
-      (Authority
-        Nothing
-        [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
-        , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
-        ])
+      ( Authority
+          Nothing
+          [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
+          , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
+          ]
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//:2000,:3000"
-      (Authority
-        Nothing
-        [ That (Port.unsafeFromInt 2000)
-        , That (Port.unsafeFromInt 3000)
-        ])
+      ( Authority
+          Nothing
+          [ That (Port.unsafeFromInt 2000)
+          , That (Port.unsafeFromInt 3000)
+          ]
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user@mongo-1,mongo-2"
-      (Authority
-        (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "user"))))
-        [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
-        , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
-        ])
+      ( Authority
+          (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "user"))))
+          [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-1")))
+          , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
+          ]
+      )
   describe "URIRef+MultiHostPortPair parser/printer" do
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://foo:bar@db1.example.net,db2.example.net:2500/authdb?replicaSet=test&connectTimeoutMS=300000"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-              (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "foo:bar"))))
-              [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db1.example.net")))
-              , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db2.example.net"))) (Port.unsafeFromInt 2500)
-              ])
-            (path ["authdb"]))
-          (Just (Query.unsafeFromString "replicaSet=test&connectTimeoutMS=300000"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "foo:bar"))))
+                      [ This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db1.example.net")))
+                      , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db2.example.net"))) (Port.unsafeFromInt 2500)
+                      ]
+                  )
+                  (path [ "authdb" ])
+              )
+              (Just (Query.unsafeFromString "replicaSet=test&connectTimeoutMS=300000"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://foo:bar@db1.example.net:6,db2.example.net:2500/authdb?replicaSet=test&connectTimeoutMS=300000"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-              (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "foo:bar"))))
-              [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db1.example.net"))) (Port.unsafeFromInt 6)
-              , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db2.example.net"))) (Port.unsafeFromInt 2500)
-              ])
-            (path ["authdb"]))
-          (Just (Query.unsafeFromString "replicaSet=test&connectTimeoutMS=300000"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "foo:bar"))))
+                      [ Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db1.example.net"))) (Port.unsafeFromInt 6)
+                      , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "db2.example.net"))) (Port.unsafeFromInt 2500)
+                      ]
+                  )
+                  (path [ "authdb" ])
+              )
+              (Just (Query.unsafeFromString "replicaSet=test&connectTimeoutMS=300000"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://192.168.0.1,192.168.0.2"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      [ This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 1))
+                      , This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 2))
+                      ]
+                  )
+                  (path [])
+              )
               Nothing
-              [ This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 1))
-              , This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 2))
-              ])
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
 
-path ∷ Array String → Path
+path :: Array String -> Path
 path = Path <<< map PathSegment.unsafeSegmentFromString
 
-options ∷ Record (URIRefOptions UserInfo (MultiHostPortPair Host Port) Path HierPath RelPath Query Fragment)
+options :: Record (URIRefOptions UserInfo (MultiHostPortPair Host Port) Path HierPath RelPath Query Fragment)
 options =
   { parseUserInfo: pure
   , printUserInfo: identity

--- a/test/URI/Extra/MultiHostPortPair.purs
+++ b/test/URI/Extra/MultiHostPortPair.purs
@@ -36,6 +36,7 @@ spec = do
           , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
           ]
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -46,6 +47,7 @@ spec = do
           , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
           ]
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -56,6 +58,7 @@ spec = do
           , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
           ]
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -66,6 +69,7 @@ spec = do
           , Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2"))) (Port.unsafeFromInt 3000)
           ]
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -76,6 +80,7 @@ spec = do
           , That (Port.unsafeFromInt 3000)
           ]
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -86,6 +91,7 @@ spec = do
           , This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "mongo-2")))
           ]
       )
+
   describe "URIRef+MultiHostPortPair parser/printer" do
     testIso
       (URIRef.parser options)
@@ -107,6 +113,7 @@ spec = do
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -127,6 +134,7 @@ spec = do
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)

--- a/test/URI/Extra/QueryPairs.purs
+++ b/test/URI/Extra/QueryPairs.purs
@@ -15,6 +15,7 @@ spec =
   describe "QueryPairs printer/parser" do
     let parser = wrapParser (NQP.parse pure pure) Query.parser
     let printer = Query.print <<< NQP.print identity identity
+
     testIso parser printer
       "?key1=value1&key2=value2&key1=value3"
       ( NQP.QueryPairs
@@ -23,19 +24,23 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "value3"))
           ]
       )
+
     testIso parser printer
       "?k%3Dey=value%3D1%3B2"
       ( NQP.QueryPairs
           [ Tuple (NQP.unsafeKeyFromString "k%3Dey") (Just (NQP.unsafeValueFromString "value%3D1%3B2")) ]
       )
+
     testIso parser printer
       "?k%3Dey=value%3D1%3B2"
       ( NQP.QueryPairs
           [ Tuple (NQP.keyFromString "k=ey") (Just (NQP.valueFromString "value=1;2")) ]
       )
+
     testIso parser printer
       "?"
       (NQP.QueryPairs [])
+
     testIso parser printer
       "?key1=&key2="
       ( NQP.QueryPairs
@@ -43,6 +48,7 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "key2") (Just (NQP.unsafeValueFromString ""))
           ]
       )
+
     testIso parser printer
       "?key1&key2"
       ( NQP.QueryPairs
@@ -50,12 +56,14 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "key2") Nothing
           ]
       )
+
     testIso parser printer
       "?key1=foo%3Bbar"
       ( NQP.QueryPairs
           [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "foo%3Bbar"))
           ]
       )
+
     testIso parser printer
       "?replicaSet=test&connectTimeoutMS=300000"
       ( NQP.QueryPairs
@@ -63,17 +71,20 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "connectTimeoutMS") (Just (NQP.unsafeValueFromString "300000"))
           ]
       )
+
     testIso parser printer
       "?fred"
       ( NQP.QueryPairs
           [ Tuple (NQP.unsafeKeyFromString "fred") Nothing ]
       )
+
     testIso parser printer
       "?objectClass?one"
       ( NQP.QueryPairs
           [ Tuple (NQP.unsafeKeyFromString "objectClass?one") Nothing
           ]
       )
+
     testIso parser printer
       "?password=&docTypeKey="
       ( NQP.QueryPairs
@@ -81,6 +92,7 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "docTypeKey") (Just (NQP.unsafeValueFromString ""))
           ]
       )
+
     testIso parser printer
       "?password=pass&docTypeKey=type&queryTimeoutSeconds=20"
       ( NQP.QueryPairs
@@ -89,6 +101,7 @@ spec =
           , Tuple (NQP.unsafeKeyFromString "queryTimeoutSeconds") (Just (NQP.unsafeValueFromString "20"))
           ]
       )
+
     testIso parser printer
       ("?code=" <> longCode)
       ( NQP.QueryPairs

--- a/test/URI/Extra/QueryPairs.purs
+++ b/test/URI/Extra/QueryPairs.purs
@@ -10,78 +10,90 @@ import URI.Common (wrapParser)
 import URI.Extra.QueryPairs as NQP
 import URI.Query as Query
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "QueryPairs printer/parser" do
     let parser = wrapParser (NQP.parse pure pure) Query.parser
     let printer = Query.print <<< NQP.print identity identity
     testIso parser printer
       "?key1=value1&key2=value2&key1=value3"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "value1"))
-        , Tuple (NQP.unsafeKeyFromString "key2") (Just (NQP.unsafeValueFromString "value2"))
-        , Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "value3"))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "value1"))
+          , Tuple (NQP.unsafeKeyFromString "key2") (Just (NQP.unsafeValueFromString "value2"))
+          , Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "value3"))
+          ]
+      )
     testIso parser printer
       "?k%3Dey=value%3D1%3B2"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "k%3Dey") (Just (NQP.unsafeValueFromString "value%3D1%3B2")) ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "k%3Dey") (Just (NQP.unsafeValueFromString "value%3D1%3B2")) ]
+      )
     testIso parser printer
       "?k%3Dey=value%3D1%3B2"
-      (NQP.QueryPairs
-        [ Tuple (NQP.keyFromString "k=ey") (Just (NQP.valueFromString "value=1;2")) ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.keyFromString "k=ey") (Just (NQP.valueFromString "value=1;2")) ]
+      )
     testIso parser printer
       "?"
       (NQP.QueryPairs [])
     testIso parser printer
       "?key1=&key2="
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString ""))
-        , Tuple (NQP.unsafeKeyFromString "key2") (Just (NQP.unsafeValueFromString ""))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString ""))
+          , Tuple (NQP.unsafeKeyFromString "key2") (Just (NQP.unsafeValueFromString ""))
+          ]
+      )
     testIso parser printer
       "?key1&key2"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "key1") Nothing
-        , Tuple (NQP.unsafeKeyFromString "key2") Nothing
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "key1") Nothing
+          , Tuple (NQP.unsafeKeyFromString "key2") Nothing
+          ]
+      )
     testIso parser printer
       "?key1=foo%3Bbar"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "foo%3Bbar"))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "key1") (Just (NQP.unsafeValueFromString "foo%3Bbar"))
+          ]
+      )
     testIso parser printer
       "?replicaSet=test&connectTimeoutMS=300000"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "replicaSet") (Just (NQP.unsafeValueFromString "test"))
-        , Tuple (NQP.unsafeKeyFromString "connectTimeoutMS") (Just (NQP.unsafeValueFromString "300000"))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "replicaSet") (Just (NQP.unsafeValueFromString "test"))
+          , Tuple (NQP.unsafeKeyFromString "connectTimeoutMS") (Just (NQP.unsafeValueFromString "300000"))
+          ]
+      )
     testIso parser printer
       "?fred"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "fred") Nothing ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "fred") Nothing ]
+      )
     testIso parser printer
       "?objectClass?one"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "objectClass?one") Nothing
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "objectClass?one") Nothing
+          ]
+      )
     testIso parser printer
       "?password=&docTypeKey="
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "password") (Just (NQP.unsafeValueFromString ""))
-        , Tuple (NQP.unsafeKeyFromString "docTypeKey") (Just (NQP.unsafeValueFromString ""))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "password") (Just (NQP.unsafeValueFromString ""))
+          , Tuple (NQP.unsafeKeyFromString "docTypeKey") (Just (NQP.unsafeValueFromString ""))
+          ]
+      )
     testIso parser printer
       "?password=pass&docTypeKey=type&queryTimeoutSeconds=20"
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "password") (Just (NQP.unsafeValueFromString "pass"))
-        , Tuple (NQP.unsafeKeyFromString "docTypeKey") (Just (NQP.unsafeValueFromString "type"))
-        , Tuple (NQP.unsafeKeyFromString "queryTimeoutSeconds") (Just (NQP.unsafeValueFromString "20"))
-        ])
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "password") (Just (NQP.unsafeValueFromString "pass"))
+          , Tuple (NQP.unsafeKeyFromString "docTypeKey") (Just (NQP.unsafeValueFromString "type"))
+          , Tuple (NQP.unsafeKeyFromString "queryTimeoutSeconds") (Just (NQP.unsafeValueFromString "20"))
+          ]
+      )
     testIso parser printer
       ("?code=" <> longCode)
-      (NQP.QueryPairs
-        [ Tuple (NQP.unsafeKeyFromString "code") (Just (NQP.unsafeValueFromString longCode))
-        ])
-    where
-      longCode = "eyJraWRiOiJjcGlTY29yZV8wOTI1MjAxNSNsInZlciI6IjEuMCIsInppcCI6IkRlZmxhdGUiLCJzZXIiOiIxLjAifQ..POoi6BeVmzh85nqw.2DBovxH_VhgEn0KQ67VlAOgPmJYxqJN-R4mrN45jGRL6Z4MiQQxn1xHmrgnvkWZ4zbTaUE8BtPoJw7nke6pLtiQqwo9y7Sf4MkkSuVbEg2b1lfmZ1gOCfRLFzAW5mWQrPEs5Vie4cjnhOZi-EkgQUQVP73apF8yjhKIZlrLdrbJV9ta8yf394rXKHeLUBU19F4tpf7zSKSJBBRfQDyouL4FbReRmnR9UHR6sixkOteNChJDoV0mnrPHPgaxaNpGLx4a1tR9DRdQnaqYUTMR0cbTEoJ1IfObKfPGdftJ2G_rsqfs9xGbmsow5BhAmF4CC9vzHtNvgPt_-N7Tz3mkTxhmX67tNT3YAgsRamduk9j_5h6aiTckh7XwcBhDbgp0PoyEXZ9mXatghLtJRZ-7B72WPKYTZs2jkF1Ir1E950I6sc2m3uw09zaGYFmxjSba-BipPD_lMzyVfIYThF_kHDHNspYb77ilhMuOhVsBkJ_-sQxPf5KdjzSGkLkgPBaZ8cCdgnantGc_DJWfl-NJWKZLNZ6w3j6nCWW4c19wjXrG-h2C8rseudSoLy_IGQSsV-4uQLKwBSRMvfmk7ysLlfBFfHD4z3XGbuyJ2vsEzVOJngl-Ynyiac8nHt8yr7pi3Bvsi9CfsYKzMbxXBreQ3EM0pzOIdnPp5IgdfOMYU0wShE4OVspmP2ppiBcWZdrD55gYNgaHjD0jJWSJR80uPEx7nt2KW3JToXBcb0MxUcDa_2A0EbsOU578NZct4MEJsVDBdfGRC6XB55g7ZNwrYCmlzMeWt2nI_QIZArNM-5dfqjlvL7uvsKQg37gJDpCdNPWV1DVC3FAU1AVwZLeyYLk2CwN4OlGxXWLfxdo6-hgAg6_mS9HXZj05Krb4geV5MiSNCHIx3IPWe_LcXlRaZCjBO8YVipIZkpyh-JQywFl2lexb-t1M1450JozXry6Afd5ek4OrZpAlFI-KDP7y1RbgBoqYloySGGvTYItclFw7gsST42B1D1OWDDWacS9p6C-xl6wDONzRXU3xOBhifLJL6JGboZIadcupYl5AKh18MivIrt5oSd2BaLuMzax9YqSYJ2U8WpYp3QRkLbokhLq_D_whV-0R6zjDHk8t3zGXiRj9JXazTcirf8emYuigMaVOW9m6KcUeHhUM_gn4oATmZ3WfvnVqSSz72j8p_GwRM3P9C_nn1jOAuxA5j66KTpQTgLj7HIkTP-sm30qIe5PwWaWQrbPenI_Zfu03JMqTXiQOCVxSwmkjYbQkWYq7p1-0Ct4Wqwt7cyfMYnDhD8JZauIO2XA5eLuTRJm3ZEYclq0IStGx_HwJSERJtuHHOGQlnEYGxKAyYb8X9jwlHe4WYwQN9Sg7uIYVDUZ5R5k_Ol5KP2jyQLO0m9aRu2-pF05w8GDU52FJnjh2LvvQXkPH2pgY2rx65sss4hqj7B0h--WdFCGpT3cLSKJndJ6XfrF8uKGf_6WvQdcxggBkckeO1pkU9etll-Aq_Dxh6St0PCgegH9Do2QXfY6X0iEnZ5-r4BGmV3HjlFwtcAR5PDv8F71wmuz2GQbZnnQBrgtBIIkILHAAnBiVy-8Tl2QmKlkieEhISrju1fMSNnc5ZQ_vggqpeN47wTzsklY0z6liAfVMsvpoCAJm-g4FroYbVSha33Lc6lUv6jxIhdveidFzKDi8Sh_i8H3XwXI68FzgmSQDzOrZkAcPkoJItq_EROxy4KC-i7KZviZMVefQ0Fktd41fM0ik5LwWl5PgGKoFy_Cy8VsMMMsOurYGBj8YdjDxzz6wqOVbNPcPuLqJHJY9StEtqqhwVCwdfGqVSD_VPn6B_3RTXKQSGt5fCXIJNvY8170HTfyioE-ixPfBErTIny5FLiSokqmrTvCH3l1XfCd2Ee8zoLaUqnzOOOE4467vFVuxZ4CfIQLt6jIxJ0Tb0BOTIBkOELFjEZ0owEiX63eaxRF7f2sst78HN1V1NzEf1WNdbikJmE1TPX1KXNIaF2nEVpfVxVN3aWUu_nNzOUVLEF55dnrTJdgy8wsF7wRtflW1GfFOfA_D2im2dDCg688R3LcVjddpg-VYwuZ7FH00xXWkoy85h9aCX8OnmfahNpuwyBcXkYDx8X4pATt-ZW6XOK7eajZnKJedMrlVFv2Ll7dwnyv74p8fYXF85ilTgRJeE5j7Tkss1gt5zHjihLJq_256DhMKMTFyTa6D_Hp0MH5HqP6SoTE8qzFSvHz_skRtVgmOrtAJ4-ZGfhXuDFhqMTehmmIF9oCirWs7qZHq2stgYoNgmIAyqgCXkvt39YEkaUhnBdt71URQ9XjCPToLSnUmcaFhV2kzoj7PkunTa4saS0ARvDXP_z3mEZ-e9II-ASwfScJV6OqyDABeuKGkxOB_ddUxnXyL1F2K0X1qzi1kJ-TVmLDseN805hl3gqPOvbdh65mAPrDw4713a3LRsOiRfDjDmR3GE3QxyTYrXFGMiGShhuCjZBZKkqw4OJqX9alY9HrwvIk7wcBlXYUcjU5G1qUK0jP8ozRRAiyO8QRVkkI830NAF52RuhxKshkx7gGQaNLU-pQGv8aPCXi2rosYJfhqlqEQ16yhezRAh2591jCLNCcDP-XXIUyrrpWZO3nHvTUfsovFJlGYrwugPulF7PSoNBBuX7rYbLaORdGB8Hi3iFnRo_tJ-kBcH03aNOLWaRO0bLFmJveJjtPsTmIbSr6wKiYxfmROMjrHDI-_ATj7x6pDJUU2IAqauZgAUYZ_ddK1z7N76CkRtXnAj1LmsEULoyVqYjTo6ggKWBnamUEltVWPHuY3IuLsmpda2kdd7--KektSvGct0aJLc84gqQdJeQCeoIQ0pSeYHMwEU61AdZk6a2xQtKZwUOvLbp5DGXgHCqx9H3H0Qj_u-iVcEEgozY3NerPkTr_AsAUGVE1vT4HrUje0sxdE_X4d5CKXafuKd4POHTVs9Y4T7icdMn4rShSnyc4NiFzUyw89-rcf014jm1ll7bQSuRMsvs9x96hvXhC1syoBR3wSt9cRnHQuEPBr48eNwtd7vgmXVPFFRa5vF_Hl8pU0e8tvuCwB2HFO6dMoHAKKlp199goNTv7Y2xF0c1jx0QbuZ0MlcVatwZsBpqbgd6_WJZn4768uKAALHJOIDkNvquq3h8nOzlpmtjNn5cGcfzHuaqwj3qiuVboA14WoJ-FT4vr_enTHO_zoeLZVUmVLR9t36Yc5dg7teuAAn9lfUukHJ1mTbMZaFBtQj6kUHWJKc_T5vHdoVFTTdTex--RQUxc97NnknlPqKOuKOO2ECyYuW8ygt4IcP4iSMWQmdXS74TEdg8I9Qtc42rzYgwb16phKPv1GpXYdCHDl-SXe9EnY2FQJiWBFYTFIOwl4PKmygbaHO2qgYtx4MUsLFiEvfgabxGqP_UBUUlPvp3iWWYvbsNqHD0sS-M9gdwGtS7ejPs9ika2NHKiOjJrJKEPjpkHuY1pdmAu5WhzH2GvXECTKrJRJhxIQoBhLxrBUVDr9iXBdDUoT3NIVuqg56HDjVinD4KG8aba5klnPibYcDtUXgssoE1rEKcfCEN8gR7-Xf20y1hQ8vhC34ayVAUVTVW3V5LoOcdSqcRJR71PiVKjTVRDrP9KdQCUWzsb0toQ950x14yGzk6cI0ZRgiKx-sRjTWlb5c2QzuD22vLGF9mWjGH-4NPhlrasr5PcdXeNmpBEZU_xKEujeuveE7GIzbMfZ-_E45Rlqflcn5ZdIK0-0HMjrZ_sjnuQ.ZjIHxProSKoNwD6Py-8FOQ"
+      ( NQP.QueryPairs
+          [ Tuple (NQP.unsafeKeyFromString "code") (Just (NQP.unsafeValueFromString longCode))
+          ]
+      )
+  where
+  longCode = "eyJraWRiOiJjcGlTY29yZV8wOTI1MjAxNSNsInZlciI6IjEuMCIsInppcCI6IkRlZmxhdGUiLCJzZXIiOiIxLjAifQ..POoi6BeVmzh85nqw.2DBovxH_VhgEn0KQ67VlAOgPmJYxqJN-R4mrN45jGRL6Z4MiQQxn1xHmrgnvkWZ4zbTaUE8BtPoJw7nke6pLtiQqwo9y7Sf4MkkSuVbEg2b1lfmZ1gOCfRLFzAW5mWQrPEs5Vie4cjnhOZi-EkgQUQVP73apF8yjhKIZlrLdrbJV9ta8yf394rXKHeLUBU19F4tpf7zSKSJBBRfQDyouL4FbReRmnR9UHR6sixkOteNChJDoV0mnrPHPgaxaNpGLx4a1tR9DRdQnaqYUTMR0cbTEoJ1IfObKfPGdftJ2G_rsqfs9xGbmsow5BhAmF4CC9vzHtNvgPt_-N7Tz3mkTxhmX67tNT3YAgsRamduk9j_5h6aiTckh7XwcBhDbgp0PoyEXZ9mXatghLtJRZ-7B72WPKYTZs2jkF1Ir1E950I6sc2m3uw09zaGYFmxjSba-BipPD_lMzyVfIYThF_kHDHNspYb77ilhMuOhVsBkJ_-sQxPf5KdjzSGkLkgPBaZ8cCdgnantGc_DJWfl-NJWKZLNZ6w3j6nCWW4c19wjXrG-h2C8rseudSoLy_IGQSsV-4uQLKwBSRMvfmk7ysLlfBFfHD4z3XGbuyJ2vsEzVOJngl-Ynyiac8nHt8yr7pi3Bvsi9CfsYKzMbxXBreQ3EM0pzOIdnPp5IgdfOMYU0wShE4OVspmP2ppiBcWZdrD55gYNgaHjD0jJWSJR80uPEx7nt2KW3JToXBcb0MxUcDa_2A0EbsOU578NZct4MEJsVDBdfGRC6XB55g7ZNwrYCmlzMeWt2nI_QIZArNM-5dfqjlvL7uvsKQg37gJDpCdNPWV1DVC3FAU1AVwZLeyYLk2CwN4OlGxXWLfxdo6-hgAg6_mS9HXZj05Krb4geV5MiSNCHIx3IPWe_LcXlRaZCjBO8YVipIZkpyh-JQywFl2lexb-t1M1450JozXry6Afd5ek4OrZpAlFI-KDP7y1RbgBoqYloySGGvTYItclFw7gsST42B1D1OWDDWacS9p6C-xl6wDONzRXU3xOBhifLJL6JGboZIadcupYl5AKh18MivIrt5oSd2BaLuMzax9YqSYJ2U8WpYp3QRkLbokhLq_D_whV-0R6zjDHk8t3zGXiRj9JXazTcirf8emYuigMaVOW9m6KcUeHhUM_gn4oATmZ3WfvnVqSSz72j8p_GwRM3P9C_nn1jOAuxA5j66KTpQTgLj7HIkTP-sm30qIe5PwWaWQrbPenI_Zfu03JMqTXiQOCVxSwmkjYbQkWYq7p1-0Ct4Wqwt7cyfMYnDhD8JZauIO2XA5eLuTRJm3ZEYclq0IStGx_HwJSERJtuHHOGQlnEYGxKAyYb8X9jwlHe4WYwQN9Sg7uIYVDUZ5R5k_Ol5KP2jyQLO0m9aRu2-pF05w8GDU52FJnjh2LvvQXkPH2pgY2rx65sss4hqj7B0h--WdFCGpT3cLSKJndJ6XfrF8uKGf_6WvQdcxggBkckeO1pkU9etll-Aq_Dxh6St0PCgegH9Do2QXfY6X0iEnZ5-r4BGmV3HjlFwtcAR5PDv8F71wmuz2GQbZnnQBrgtBIIkILHAAnBiVy-8Tl2QmKlkieEhISrju1fMSNnc5ZQ_vggqpeN47wTzsklY0z6liAfVMsvpoCAJm-g4FroYbVSha33Lc6lUv6jxIhdveidFzKDi8Sh_i8H3XwXI68FzgmSQDzOrZkAcPkoJItq_EROxy4KC-i7KZviZMVefQ0Fktd41fM0ik5LwWl5PgGKoFy_Cy8VsMMMsOurYGBj8YdjDxzz6wqOVbNPcPuLqJHJY9StEtqqhwVCwdfGqVSD_VPn6B_3RTXKQSGt5fCXIJNvY8170HTfyioE-ixPfBErTIny5FLiSokqmrTvCH3l1XfCd2Ee8zoLaUqnzOOOE4467vFVuxZ4CfIQLt6jIxJ0Tb0BOTIBkOELFjEZ0owEiX63eaxRF7f2sst78HN1V1NzEf1WNdbikJmE1TPX1KXNIaF2nEVpfVxVN3aWUu_nNzOUVLEF55dnrTJdgy8wsF7wRtflW1GfFOfA_D2im2dDCg688R3LcVjddpg-VYwuZ7FH00xXWkoy85h9aCX8OnmfahNpuwyBcXkYDx8X4pATt-ZW6XOK7eajZnKJedMrlVFv2Ll7dwnyv74p8fYXF85ilTgRJeE5j7Tkss1gt5zHjihLJq_256DhMKMTFyTa6D_Hp0MH5HqP6SoTE8qzFSvHz_skRtVgmOrtAJ4-ZGfhXuDFhqMTehmmIF9oCirWs7qZHq2stgYoNgmIAyqgCXkvt39YEkaUhnBdt71URQ9XjCPToLSnUmcaFhV2kzoj7PkunTa4saS0ARvDXP_z3mEZ-e9II-ASwfScJV6OqyDABeuKGkxOB_ddUxnXyL1F2K0X1qzi1kJ-TVmLDseN805hl3gqPOvbdh65mAPrDw4713a3LRsOiRfDjDmR3GE3QxyTYrXFGMiGShhuCjZBZKkqw4OJqX9alY9HrwvIk7wcBlXYUcjU5G1qUK0jP8ozRRAiyO8QRVkkI830NAF52RuhxKshkx7gGQaNLU-pQGv8aPCXi2rosYJfhqlqEQ16yhezRAh2591jCLNCcDP-XXIUyrrpWZO3nHvTUfsovFJlGYrwugPulF7PSoNBBuX7rYbLaORdGB8Hi3iFnRo_tJ-kBcH03aNOLWaRO0bLFmJveJjtPsTmIbSr6wKiYxfmROMjrHDI-_ATj7x6pDJUU2IAqauZgAUYZ_ddK1z7N76CkRtXnAj1LmsEULoyVqYjTo6ggKWBnamUEltVWPHuY3IuLsmpda2kdd7--KektSvGct0aJLc84gqQdJeQCeoIQ0pSeYHMwEU61AdZk6a2xQtKZwUOvLbp5DGXgHCqx9H3H0Qj_u-iVcEEgozY3NerPkTr_AsAUGVE1vT4HrUje0sxdE_X4d5CKXafuKd4POHTVs9Y4T7icdMn4rShSnyc4NiFzUyw89-rcf014jm1ll7bQSuRMsvs9x96hvXhC1syoBR3wSt9cRnHQuEPBr48eNwtd7vgmXVPFFRa5vF_Hl8pU0e8tvuCwB2HFO6dMoHAKKlp199goNTv7Y2xF0c1jx0QbuZ0MlcVatwZsBpqbgd6_WJZn4768uKAALHJOIDkNvquq3h8nOzlpmtjNn5cGcfzHuaqwj3qiuVboA14WoJ-FT4vr_enTHO_zoeLZVUmVLR9t36Yc5dg7teuAAn9lfUukHJ1mTbMZaFBtQj6kUHWJKc_T5vHdoVFTTdTex--RQUxc97NnknlPqKOuKOO2ECyYuW8ygt4IcP4iSMWQmdXS74TEdg8I9Qtc42rzYgwb16phKPv1GpXYdCHDl-SXe9EnY2FQJiWBFYTFIOwl4PKmygbaHO2qgYtx4MUsLFiEvfgabxGqP_UBUUlPvp3iWWYvbsNqHD0sS-M9gdwGtS7ejPs9ika2NHKiOjJrJKEPjpkHuY1pdmAu5WhzH2GvXECTKrJRJhxIQoBhLxrBUVDr9iXBdDUoT3NIVuqg56HDjVinD4KG8aba5klnPibYcDtUXgssoE1rEKcfCEN8gR7-Xf20y1hQ8vhC34ayVAUVTVW3V5LoOcdSqcRJR71PiVKjTVRDrP9KdQCUWzsb0toQ950x14yGzk6cI0ZRgiKx-sRjTWlb5c2QzuD22vLGF9mWjGH-4NPhlrasr5PcdXeNmpBEZU_xKEujeuveE7GIzbMfZ-_E45Rlqflcn5ZdIK0-0HMjrZ_sjnuQ.ZjIHxProSKoNwD6Py-8FOQ"

--- a/test/URI/Extra/UserPassInfo.purs
+++ b/test/URI/Extra/UserPassInfo.purs
@@ -28,6 +28,7 @@ spec = do
           (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Nothing }))
           (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -36,6 +37,7 @@ spec = do
           (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pass")) }))
           (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -44,6 +46,7 @@ spec = do
           (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
           (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -52,6 +55,7 @@ spec = do
           (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
           (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)
@@ -60,6 +64,7 @@ spec = do
           (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
           (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
       )
+
     testIso
       (Authority.parser options)
       (Authority.print options)

--- a/test/URI/Extra/UserPassInfo.purs
+++ b/test/URI/Extra/UserPassInfo.purs
@@ -17,53 +17,59 @@ import URI.HostPortPair (HostPortPair)
 import URI.HostPortPair as HostPortPair
 import URI.URIRef (Fragment, HierPath, Path, Query, RelPath, URIRefOptions)
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec = do
   describe "Authority+UserPassInfo parser/printer" do
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Nothing }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Nothing }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user:pass@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pass")) }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pass")) }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user:pa%3Ass@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//us%3Aer:pa%3Ass@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//us%3Aer:pa%3Ass@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "us:er"), password: Just (nes (Proxy :: Proxy "pa:ss")) }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
     testIso
       (Authority.parser options)
       (Authority.print options)
       "//user:p%40ss@host"
-      (Authority
-        (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "p@ss")) }))
-        (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host"))))))
+      ( Authority
+          (Just (UserPassInfo { user: nes (Proxy :: Proxy "user"), password: Just (nes (Proxy :: Proxy "p@ss")) }))
+          (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "host")))))
+      )
 
-options ∷ Record (URIRefOptions UserPassInfo (HostPortPair Host Port) Path HierPath RelPath Query Fragment)
+options :: Record (URIRefOptions UserPassInfo (HostPortPair Host Port) Path HierPath RelPath Query Fragment)
 options =
   { parseUserInfo: UserPassInfo.parse
   , printUserInfo: UserPassInfo.print

--- a/test/URI/Fragment.purs
+++ b/test/URI/Fragment.purs
@@ -6,7 +6,7 @@ import Test.Spec (Spec, describe)
 import Test.Util (testIso)
 import URI.Fragment as Fragment
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "Fragment parser/printer" do
     testIso Fragment.parser Fragment.print "#" (Fragment.fromString "")

--- a/test/URI/Host.purs
+++ b/test/URI/Host.purs
@@ -16,7 +16,7 @@ import URI.Host.IPv4Address as IPv4Address
 import URI.Host.IPv6Address as IPv6Address
 import URI.Host.RegName as RegName
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec = do
   describe "Host parser/printer" do
     testIso Host.parser Host.print "localhost" (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))
@@ -29,7 +29,7 @@ spec = do
 
     it "should successfully roundtrip values sent through Host parse/print" do
       forAll do
-        ipv4 ← Host.Gen.genIPv4
+        ipv4 <- Host.Gen.genIPv4
         let printed = IPv4Address.print ipv4
         let parsed = runParser printed Host.parser
         pure $ pure (IPv4Address ipv4) === parsed
@@ -43,5 +43,5 @@ spec = do
 
     it "should uphold toString / fromString property" do
       forAll do
-        regName ← Host.Gen.genRegName
+        regName <- Host.Gen.genRegName
         pure $ RegName.fromString (RegName.toString regName) === regName

--- a/test/URI/Path.purs
+++ b/test/URI/Path.purs
@@ -8,7 +8,7 @@ import URI.Path (Path(..))
 import URI.Path as Path
 import URI.Path.Segment as PathSegment
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "Path parser/printer" do
-    testIso Path.parser Path.print "/%D0%9F%D0%B0%D1%86%D0%B8%D0%B5%D0%BD%D1%82%D1%8B%23%20%23" (Path [PathSegment.segmentFromString "Пациенты# #"])
+    testIso Path.parser Path.print "/%D0%9F%D0%B0%D1%86%D0%B8%D0%B5%D0%BD%D1%82%D1%8B%23%20%23" (Path [ PathSegment.segmentFromString "Пациенты# #" ])

--- a/test/URI/Port.purs
+++ b/test/URI/Port.purs
@@ -9,7 +9,7 @@ import Test.Util (forAll, testIso)
 import URI.Port as Port
 import URI.Port.Gen as Port.Gen
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "Port parser/printer" do
     testIso Port.parser Port.print ":0" (Port.unsafeFromInt 0)
@@ -18,5 +18,5 @@ spec =
 
     it "should uphold toString / fromString property" do
       forAll do
-        port ← Port.Gen.genPort
+        port <- Port.Gen.genPort
         pure $ Port.fromInt (Port.toInt port) === Just port

--- a/test/URI/Scheme.purs
+++ b/test/URI/Scheme.purs
@@ -14,13 +14,9 @@ spec = do
     testIso Scheme.parser Scheme.print "http:" (Scheme.unsafeFromString "http")
     testIso Scheme.parser Scheme.print "git+ssh:" (Scheme.unsafeFromString "git+ssh")
   describe "Scheme fromString/toString" do
-    it "http"
-      let
-        http = Scheme.unsafeFromString "http"
-      in
-        equal (Just http) $ Scheme.fromString $ NES.toString $ Scheme.toString http
-    it "git+ssh"
-      let
-        git = Scheme.unsafeFromString "git+ssh"
-      in
-        equal (Just git) $ Scheme.fromString $ NES.toString $ Scheme.toString git
+    it "http" do
+      let http = Scheme.unsafeFromString "http"
+      equal (Just http) $ Scheme.fromString $ NES.toString $ Scheme.toString http
+    it "git+ssh" do
+      let git = Scheme.unsafeFromString "git+ssh"
+      equal (Just git) $ Scheme.fromString $ NES.toString $ Scheme.toString git

--- a/test/URI/Scheme.purs
+++ b/test/URI/Scheme.purs
@@ -8,15 +8,19 @@ import Test.Spec (Spec, describe, it)
 import Test.Util (testIso, equal)
 import URI.Scheme as Scheme
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec = do
   describe "Scheme parser/printer" do
     testIso Scheme.parser Scheme.print "http:" (Scheme.unsafeFromString "http")
     testIso Scheme.parser Scheme.print "git+ssh:" (Scheme.unsafeFromString "git+ssh")
   describe "Scheme fromString/toString" do
     it "http"
-      let http = Scheme.unsafeFromString "http"
-      in equal (Just http) $ Scheme.fromString $ NES.toString $ Scheme.toString http
+      let
+        http = Scheme.unsafeFromString "http"
+      in
+        equal (Just http) $ Scheme.fromString $ NES.toString $ Scheme.toString http
     it "git+ssh"
-      let git = Scheme.unsafeFromString "git+ssh"
-      in equal (Just git) $ Scheme.fromString $ NES.toString $ Scheme.toString git
+      let
+        git = Scheme.unsafeFromString "git+ssh"
+      in
+        equal (Just git) $ Scheme.fromString $ NES.toString $ Scheme.toString git

--- a/test/URI/URIRef.purs
+++ b/test/URI/URIRef.purs
@@ -42,6 +42,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -57,6 +58,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -69,6 +71,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -81,6 +84,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -99,6 +103,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -117,6 +122,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -135,6 +141,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -153,6 +160,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -171,6 +179,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -189,6 +198,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -207,6 +217,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -225,6 +236,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -243,6 +255,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -261,6 +274,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -279,6 +293,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -297,6 +312,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -315,6 +331,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -333,6 +350,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -351,6 +369,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -369,6 +388,7 @@ spec =
               (Just (Fragment.unsafeFromString "nose"))
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -387,6 +407,7 @@ spec =
               (Just (Fragment.unsafeFromString ""))
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -405,6 +426,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -423,6 +445,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -434,6 +457,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -445,6 +469,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -456,6 +481,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -467,6 +493,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -478,6 +505,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -493,6 +521,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -508,6 +537,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -520,6 +550,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -532,6 +563,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -544,6 +576,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -556,6 +589,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -568,6 +602,7 @@ spec =
               Nothing
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)
@@ -586,6 +621,7 @@ spec =
               (Just (Fragment.unsafeFromString "?sort=asc&q=path%3A%2F&salt=1177214"))
           )
       )
+
     testIso
       (URIRef.parser options)
       (URIRef.print options)

--- a/test/URI/URIRef.purs
+++ b/test/URI/URIRef.purs
@@ -24,471 +24,591 @@ import URI.URIRef (Authority(..), Fragment, HierPath, HierarchicalPart(..), Host
 import URI.URIRef as URIRef
 import URI.UserInfo as UserInfo
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "URIRef parser/printer" do
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "sql2:///?q=foo&var.bar=baz"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "sql2")
-          (HierarchicalPartAuth
-            (Authority Nothing Nothing)
-            (path [""]))
-          (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "sql2")
+              ( HierarchicalPartAuth
+                  (Authority Nothing Nothing)
+                  (path [ "" ])
+              )
+              (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "sql2://?q=foo&var.bar=baz"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "sql2")
-          (HierarchicalPartAuth
-            (Authority Nothing Nothing)
-            (path []))
-          (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "sql2")
+              ( HierarchicalPartAuth
+                  (Authority Nothing Nothing)
+                  (path [])
+              )
+              (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "sql2:/?q=foo&var.bar=baz"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "sql2")
-          (HierarchicalPartNoAuth (Just (Left (PathAbsolute Nothing))))
-          (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "sql2")
+              (HierarchicalPartNoAuth (Just (Left (PathAbsolute Nothing))))
+              (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "sql2:?q=foo&var.bar=baz"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "sql2")
-          (HierarchicalPartNoAuth Nothing)
-          (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "sql2")
+              (HierarchicalPartNoAuth Nothing)
+              (Just (Query.unsafeFromString "q=foo&var.bar=baz"))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://localhost"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+                  )
+                  (path [])
+              )
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "https://1a.example.com"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "https")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "https")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "1a.example.com")))))
+                  )
+                  (path [])
+              )
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "1a.example.com"))))))
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://en.wikipedia.org/wiki/URI_scheme"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "en.wikipedia.org")))))
+                  )
+                  (path [ "wiki", "URI_scheme" ])
+              )
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "en.wikipedia.org"))))))
-            (path ["wiki", "URI_scheme"]))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://192.168.0.1"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-                Nothing
-                (Just (This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 1)))))
-            (path []))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (IPv4Address (IPv4Address.unsafeFromInts 192 168 0 1))))
+                  )
+                  (path [])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://sysop:moon@localhost"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-              (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-            (path []))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+                  )
+                  (path [])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://sysop:moon@localhost/"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-                (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
-                (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-            (path [""]))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+                  )
+                  (path [ "" ])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://sysop:moon@localhost/records"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-                (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
-                (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-            (path ["records"]))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+                  )
+                  (path [ "records" ])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mongodb://sysop:moon@localhost/records/etc/"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mongodb")
-          (HierarchicalPartAuth
-            (Authority
-                (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
-                (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))))))
-            (path ["records", "etc", ""]))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mongodb")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "sysop:moon"))))
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost")))))
+                  )
+                  (path [ "records", "etc", "" ])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://[2001:cdba:0000:0000:0000:0000:3257:9652]"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (IPv6Address (IPv6Address.unsafeFromString "2001:cdba:0000:0000:0000:0000:3257:9652"))))
+                  )
+                  (path [])
+              )
               Nothing
-              (Just (This (IPv6Address (IPv6Address.unsafeFromString "2001:cdba:0000:0000:0000:0000:3257:9652")))))
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://[FE80::0202:B3FF:FE1E:8329]"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (IPv6Address (IPv6Address.unsafeFromString "FE80::0202:B3FF:FE1E:8329"))))
+                  )
+                  (path [])
+              )
               Nothing
-              (Just (This (IPv6Address (IPv6Address.unsafeFromString "FE80::0202:B3FF:FE1E:8329")))))
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://[2001:db8::1]:80"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (Both (IPv6Address (IPv6Address.unsafeFromString "2001:db8::1")) (Port.unsafeFromInt 80)))
+                  )
+                  (path [])
+              )
               Nothing
-              (Just (Both (IPv6Address (IPv6Address.unsafeFromString "2001:db8::1")) (Port.unsafeFromInt 80))))
-            (path []))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "ftp://ftp.is.co.za/rfc/rfc1808.txt"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "ftp")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "ftp")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "ftp.is.co.za")))))
+                  )
+                  (path [ "rfc", "rfc1808.txt" ])
+              )
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "ftp.is.co.za"))))))
-            (path ["rfc", "rfc1808.txt"]))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://www.ietf.org/rfc/rfc2396.txt"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "www.ietf.org")))))
+                  )
+                  (path [ "rfc", "rfc2396.txt" ])
+              )
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "www.ietf.org"))))))
-            (path ["rfc", "rfc2396.txt"]))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "ldap://[2001:db8::7]/c=GB?objectClass?one"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "ldap")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "ldap")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (IPv6Address (IPv6Address.unsafeFromString "2001:db8::7"))))
+                  )
+                  (path [ "c=GB" ])
+              )
+              (Just (Query.unsafeFromString "objectClass?one"))
               Nothing
-              (Just (This (IPv6Address (IPv6Address.unsafeFromString "2001:db8::7")))))
-            (path ["c=GB"]))
-          (Just (Query.unsafeFromString "objectClass?one"))
-          Nothing))
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "telnet://192.0.2.16:80/"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "telnet")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "telnet")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (Both (IPv4Address (IPv4Address.unsafeFromInts 192 0 2 16)) (Port.unsafeFromInt 80)))
+                  )
+                  (path [ "" ])
+              )
               Nothing
-              (Just (Both (IPv4Address (IPv4Address.unsafeFromInts 192 0 2 16)) (Port.unsafeFromInt 80))))
-            (path [""]))
-          Nothing
-          Nothing))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://example.com:8042/over/there?name=ferret#nose"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
-              Nothing
-              (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "example.com"))) (Port.unsafeFromInt 8042))))
-            (path ["over", "there"]))
-          (Just (Query.unsafeFromString "name=ferret"))
-          (Just (Fragment.unsafeFromString "nose"))))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "example.com"))) (Port.unsafeFromInt 8042)))
+                  )
+                  (path [ "over", "there" ])
+              )
+              (Just (Query.unsafeFromString "name=ferret"))
+              (Just (Fragment.unsafeFromString "nose"))
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://example.com:8042/over/there?name=ferret#"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
-              Nothing
-              (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "example.com"))) (Port.unsafeFromInt 8042))))
-            (path ["over", "there"]))
-          (Just (Query.unsafeFromString "name=ferret"))
-          (Just (Fragment.unsafeFromString ""))))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "example.com"))) (Port.unsafeFromInt 8042)))
+                  )
+                  (path [ "over", "there" ])
+              )
+              (Just (Query.unsafeFromString "name=ferret"))
+              (Just (Fragment.unsafeFromString ""))
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "foo://info.example.com?fred"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "foo")
-          (HierarchicalPartAuth
-            (Authority
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "foo")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "info.example.com")))))
+                  )
+                  (path [])
+              )
+              (Just (Query.unsafeFromString "fred"))
               Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "info.example.com"))))))
-            (path []))
-          (Just (Query.unsafeFromString "fred"))
-          Nothing))
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "ftp://cnn.example.com&story=breaking_news@10.0.0.1/top_story.htm"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "ftp")
-          (HierarchicalPartAuth
-            (Authority
-              (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "cnn.example.com&story=breaking_news"))))
-              (Just (This (IPv4Address (IPv4Address.unsafeFromInts 10 0 0 1)))))
-            (path ["top_story.htm"]))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "ftp")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      (Just (UserInfo.unsafeFromString (nes (Proxy :: Proxy "cnn.example.com&story=breaking_news"))))
+                      (Just (This (IPv4Address (IPv4Address.unsafeFromInts 10 0 0 1))))
+                  )
+                  (path [ "top_story.htm" ])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "top_story.htm"
-      (Right
-        (RelativeRef
-          (RelativePartNoAuth (Just (Right (PathNoScheme (Tuple (PathSegment.unsafeSegmentNZNCFromString $ nes (Proxy :: Proxy "top_story.htm")) [])))))
-          Nothing
-          Nothing))
+      ( Right
+          ( RelativeRef
+              (RelativePartNoAuth (Just (Right (PathNoScheme (Tuple (PathSegment.unsafeSegmentNZNCFromString $ nes (Proxy :: Proxy "top_story.htm")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "../top_story.htm"
-      (Right
-        (RelativeRef
-          (RelativePartNoAuth (Just (Right (PathNoScheme (Tuple (PathSegment.unsafeSegmentNZNCFromString $ nes (Proxy :: Proxy "..")) [PathSegment.unsafeSegmentFromString "top_story.htm"])))))
-          Nothing
-          Nothing))
+      ( Right
+          ( RelativeRef
+              (RelativePartNoAuth (Just (Right (PathNoScheme (Tuple (PathSegment.unsafeSegmentNZNCFromString $ nes (Proxy :: Proxy "..")) [ PathSegment.unsafeSegmentFromString "top_story.htm" ])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "/top_story.htm"
-      (Right
-        (RelativeRef
-          (RelativePartNoAuth (Just (Left (PathAbsolute (Just (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "top_story.htm")) []))))))
-          Nothing
-          Nothing))
+      ( Right
+          ( RelativeRef
+              (RelativePartNoAuth (Just (Left (PathAbsolute (Just (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "top_story.htm")) []))))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "/"
-      (Right
-        (RelativeRef
-          (RelativePartNoAuth (Just (Left (PathAbsolute Nothing))))
-          Nothing
-          Nothing))
+      ( Right
+          ( RelativeRef
+              (RelativePartNoAuth (Just (Left (PathAbsolute Nothing))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       ""
-      (Right
-        (RelativeRef
-          (RelativePartNoAuth Nothing)
-          Nothing
-          Nothing))
+      ( Right
+          ( RelativeRef
+              (RelativePartNoAuth Nothing)
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://www.example.com/some%20invented/url%20with%20spaces.html"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority Nothing (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "www.example.com"))))))
-            (path ["some%20invented", "url%20with%20spaces.html"]))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  (Authority Nothing (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "www.example.com"))))))
+                  (path [ "some%20invented", "url%20with%20spaces.html" ])
+              )
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://localhost:53174/metadata/fs/test/%D0%9F%D0%B0%D1%86%D0%B8%D0%B5%D0%BD%D1%82%D1%8B%23%20%23?"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority Nothing (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))) (Port.unsafeFromInt 53174))))
-            (path ["metadata", "fs", "test", "%D0%9F%D0%B0%D1%86%D0%B8%D0%B5%D0%BD%D1%82%D1%8B%23%20%23"]))
-          (Just (Query.unsafeFromString ""))
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  (Authority Nothing (Just (Both (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "localhost"))) (Port.unsafeFromInt 53174))))
+                  (path [ "metadata", "fs", "test", "%D0%9F%D0%B0%D1%86%D0%B8%D0%B5%D0%BD%D1%82%D1%8B%23%20%23" ])
+              )
+              (Just (Query.unsafeFromString ""))
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "news:comp.infosystems.www.servers.unix"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "news")
-          (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "comp.infosystems.www.servers.unix")) [])))))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "news")
+              (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "comp.infosystems.www.servers.unix")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "tel:+1-816-555-1212"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "tel")
-          (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "+1-816-555-1212")) [])))))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "tel")
+              (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "+1-816-555-1212")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "urn")
-          (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "oasis:names:specification:docbook:dtd:xml:4.1.2")) [])))))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "urn")
+              (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "oasis:names:specification:docbook:dtd:xml:4.1.2")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mailto:John.Doe@example.com"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mailto")
-          (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "John.Doe@example.com")) [])))))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mailto")
+              (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "John.Doe@example.com")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "mailto:fred@example.com"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "mailto")
-          (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "fred@example.com")) [])))))
-          Nothing
-          Nothing))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "mailto")
+              (HierarchicalPartNoAuth (Just (Right (PathRootless (Tuple (PathSegment.unsafeSegmentNZFromString $ nes (Proxy :: Proxy "fred@example.com")) [])))))
+              Nothing
+              Nothing
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://local.slamdata.com/?#?sort=asc&q=path%3A%2F&salt=1177214"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority
-              Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "local.slamdata.com"))))))
-            (path [""]))
-          (Just (Query.unsafeFromString ""))
-          (Just (Fragment.unsafeFromString "?sort=asc&q=path%3A%2F&salt=1177214"))))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "local.slamdata.com")))))
+                  )
+                  (path [ "" ])
+              )
+              (Just (Query.unsafeFromString ""))
+              (Just (Fragment.unsafeFromString "?sort=asc&q=path%3A%2F&salt=1177214"))
+          )
+      )
     testIso
       (URIRef.parser options)
       (URIRef.print options)
       "http://local.slamdata.com/?#?sort=asc&q=path:/&salt=1177214"
-      (Left
-        (URI
-          (Scheme.unsafeFromString "http")
-          (HierarchicalPartAuth
-            (Authority
-              Nothing
-              (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "local.slamdata.com"))))))
-            (path [""]))
-          (Just (Query.unsafeFromString ""))
-          (Just (Fragment.unsafeFromString "?sort=asc&q=path:/&salt=1177214"))))
+      ( Left
+          ( URI
+              (Scheme.unsafeFromString "http")
+              ( HierarchicalPartAuth
+                  ( Authority
+                      Nothing
+                      (Just (This (NameAddress (RegName.unsafeFromString $ nes (Proxy :: Proxy "local.slamdata.com")))))
+                  )
+                  (path [ "" ])
+              )
+              (Just (Query.unsafeFromString ""))
+              (Just (Fragment.unsafeFromString "?sort=asc&q=path:/&salt=1177214"))
+          )
+      )
 
-path ∷ Array String → Path
+path :: Array String -> Path
 path = Path <<< map PathSegment.unsafeSegmentFromString
 
-options ∷ Record (URIRefOptions UserInfo (HostPortPair Host Port) Path HierPath RelPath Query Fragment)
+options :: Record (URIRefOptions UserInfo (HostPortPair Host Port) Path HierPath RelPath Query Fragment)
 options =
   { parseUserInfo: pure
   , printUserInfo: identity

--- a/test/URI/UserInfo.purs
+++ b/test/URI/UserInfo.purs
@@ -8,7 +8,7 @@ import Test.Spec (Spec, describe)
 import Test.Util (testIso)
 import URI.UserInfo as UserInfo
 
-spec ∷ Spec Unit
+spec :: Spec Unit
 spec =
   describe "UserInfo parser/printer" do
     testIso UserInfo.parser UserInfo.print "user" (UserInfo.fromString (nes (Proxy :: Proxy "user")))

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -25,7 +25,8 @@ equal :: forall a. Eq a => Show a => a -> a -> Spec Unit
 equal expected actual =
   when (expected /= actual) do
     fail $
-      "\nexpected: " <> show expected
+      "\nexpected: "
+        <> show expected
         <> "\ngot:      "
         <> show actual
 

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -9,13 +9,13 @@ import Test.QuickCheck.Gen as QCG
 import Test.Spec (Spec, it, fail)
 import Text.Parsing.Parser (Parser, runParser)
 
-testPrinter ∷ ∀ a. Show a ⇒ (a → String) → String → a → Spec Unit
+testPrinter :: forall a. Show a => (a -> String) -> String -> a -> Spec Unit
 testPrinter f expected value =
   it
     ("prints: " <> expected)
     (equal expected (f value))
 
-testParser ∷ ∀ a. Eq a ⇒ Show a ⇒ Parser String a → String → a → Spec Unit
+testParser :: forall a. Eq a => Show a => Parser String a -> String -> a -> Spec Unit
 testParser p value expected =
   it
     ("parses: " <> value)
@@ -25,16 +25,17 @@ equal :: forall a. Eq a => Show a => a -> a -> Spec Unit
 equal expected actual =
   when (expected /= actual) do
     fail $
-      "\nexpected: " <> show expected <>
-      "\ngot:      " <> show actual
+      "\nexpected: " <> show expected
+        <> "\ngot:      "
+        <> show actual
 
-testIso ∷ ∀ a. Eq a ⇒ Show a ⇒ Parser String a → (a → String) → String → a → Spec Unit
+testIso :: forall a. Eq a => Show a => Parser String a -> (a -> String) -> String -> a -> Spec Unit
 testIso p f value expected = do
   testParser p value expected
   testPrinter f value expected
 
-forAll ∷ ∀ prop. QC.Testable prop ⇒ QCG.Gen prop → Spec Unit
+forAll :: forall prop. QC.Testable prop => QCG.Gen prop -> Spec Unit
 forAll = quickCheck
 
-quickCheck ∷ ∀ prop. QC.Testable prop ⇒ prop → Spec Unit
+quickCheck :: forall prop. QC.Testable prop => prop -> Spec Unit
 quickCheck = liftEffect <<< QC.quickCheck' 100


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
