### PR TITLE
Avoid exceptions when URI encoding fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 
 Bugfixes:
 - Made all parsers stack safe on long input (#63 by @garyb)
+- Exceptions are no longer thrown when using e.g. `valueFromString` with lone surrogates (#68 by @ysangkok)
 
 Other improvements:
 - Added `purs-tidy` formatter (#66 by @thomashoneyman)

--- a/test/URI/Extra/QueryPairs.purs
+++ b/test/URI/Extra/QueryPairs.purs
@@ -4,14 +4,22 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
-import Test.Spec (Spec, describe)
-import Test.Util (testIso)
+import Test.Spec (Spec, describe, it)
+import Test.Util (forAll, testIso)
+import Test.QuickCheck ((===))
+import Test.QuickCheck.Arbitrary (arbitrary)
 import URI.Common (wrapParser)
 import URI.Extra.QueryPairs as NQP
 import URI.Query as Query
 
 spec :: Spec Unit
-spec =
+spec = do
+  describe "valueFromString" do
+    it "should not throw exceptions for any inputs" do
+      forAll do
+        unencoded <- arbitrary
+        pure $ NQP.valueFromString unencoded === NQP.valueFromString unencoded
+
   describe "QueryPairs printer/parser" do
     let parser = wrapParser (NQP.parse pure pure) Query.parser
     let printer = Query.print <<< NQP.print identity identity


### PR DESCRIPTION
**Description of the change**
- Test valueFromString with QuickCheck
- Avoid exception when URI encoding fails
- Add changelog item

I havn't marked it as solving #68 since there is still a `fromJust` left.

---

**Checklist:**

- [X] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation in the README and/or documentation directory
- [X] Added a test for the contribution (if applicable)
